### PR TITLE
Don't use deprecated apps schema path

### DIFF
--- a/data/org.mate.mate-calc.gschema.xml.in
+++ b/data/org.mate.mate-calc.gschema.xml.in
@@ -17,7 +17,7 @@
     <value value="2" nick="gradians"/>
   </enum>
 
-  <schema path="/apps/mate-calc/" id="org.mate.mate-calc" gettext-domain="mate-calc">
+  <schema path="/org/mate/mate-calc/" id="org.mate.mate-calc" gettext-domain="mate-calc">
     <key type="i" name="accuracy">
       <default>9</default>
       <range min="0" max="9"/>


### PR DESCRIPTION
This changes the schema path from /apps/mate-calc/ to /org/mate/mate-calc/ to match the schema id since /apps/ is deprecated according to http://developer.gnome.org/gio/2.32/GSettings.html.

This is kind of redundant (mate twice), so another option would be to change the id and path to something like org.mate.calculator. Would that method be preferred?
