### PR TITLE
Use org.mate.calc as schema id

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -6,7 +6,7 @@ ui_DATA = \
 	buttons-financial.ui \
 	buttons-programming.ui
 
-gsettings_SCHEMAS = org.mate.mate-calc.gschema.xml
+gsettings_SCHEMAS = org.mate.calc.gschema.xml
 @INTLTOOL_XML_NOMERGE_RULE@
 @GSETTINGS_RULES@
 
@@ -17,7 +17,7 @@ Utilities_DATA = $(Utilities_in_files:.desktop.in=.desktop)
 
 man1_MANS = mate-calc.1
 
-EXTRA_DIST = $(ui_DATA) org.mate.mate-calc.gschema.xml.in mate-calc.desktop.in $(man1_MANS)
+EXTRA_DIST = $(ui_DATA) org.mate.calc.gschema.xml.in mate-calc.desktop.in $(man1_MANS)
 
 DISTCLEANFILES = \
 	Makefile.in \

--- a/data/org.mate.calc.gschema.xml.in
+++ b/data/org.mate.calc.gschema.xml.in
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
-  <enum id="org.mate.mate-calc.NumberFormat">
+  <enum id="org.mate.calc.NumberFormat">
     <value value="0" nick="fixed"/>
     <value value="1" nick="scientific"/>
     <value value="2" nick="engineering"/>
   </enum>
-  <enum id="org.mate.mate-calc.ButtonMode">
+  <enum id="org.mate.calc.ButtonMode">
     <value value="0" nick="basic"/>
     <value value="1" nick="advanced"/>
     <value value="2" nick="financial"/>
     <value value="3" nick="programming"/>
   </enum>
-  <enum id="org.mate.mate-calc.AngleUnit">
+  <enum id="org.mate.calc.AngleUnit">
     <value value="0" nick="radians"/>
     <value value="1" nick="degrees"/>
     <value value="2" nick="gradians"/>
   </enum>
 
-  <schema path="/org/mate/mate-calc/" id="org.mate.mate-calc" gettext-domain="mate-calc">
+  <schema path="/org/mate/calc/" id="org.mate.calc" gettext-domain="mate-calc">
     <key type="i" name="accuracy">
       <default>9</default>
       <range min="0" max="9"/>
@@ -46,17 +46,17 @@
       <_summary>Show Trailing Zeroes</_summary>
       <_description>Indicates whether any trailing zeroes after the  numeric point should be shown in the display value.</_description>
     </key>
-    <key name="number-format" enum="org.mate.mate-calc.NumberFormat">
+    <key name="number-format" enum="org.mate.calc.NumberFormat">
       <default>'fixed'</default>
       <_summary>Number format</_summary>
       <_description>The format to display numbers in</_description>
     </key>
-    <key name="angle-units" enum="org.mate.mate-calc.AngleUnit">
+    <key name="angle-units" enum="org.mate.calc.AngleUnit">
       <default>'degrees'</default>
       <_summary>Angle units</_summary>
       <_description>The angle units to use</_description>
     </key>
-    <key name="button-mode" enum="org.mate.mate-calc.ButtonMode">
+    <key name="button-mode" enum="org.mate.calc.ButtonMode">
       <default>'basic'</default>
       <_summary>Button mode</_summary>
       <_description>The button mode</_description>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -7,7 +7,7 @@
 [type: gettext/glade]data/buttons-programming.ui
 [type: gettext/glade]data/preferences.ui
 data/mate-calc.desktop.in
-data/org.mate.mate-calc.gschema.xml.in
+data/org.mate.calc.gschema.xml.in
 src/currency.c
 src/currency.h
 src/financial.c

--- a/src/mate-calc.c
+++ b/src/mate-calc.c
@@ -222,7 +222,7 @@ main(int argc, char **argv)
 
     get_options(argc, argv);
 
-    settings = g_settings_new ("org.mate.mate-calc");
+    settings = g_settings_new ("org.mate.calc");
     accuracy = g_settings_get_int(settings, "accuracy");
     word_size = g_settings_get_int(settings, "word-size");
     base = g_settings_get_int(settings, "base");


### PR DESCRIPTION
This changes org.mate.mate-calc to org.mate.calc and /org/mate/mate-calc/ to /org/mate/calc/ for gsettings.

The caja-open-terminal extension has a similar problem (/apps/caja-open-terminal/ and org.mate.apps.caja-open-terminal) Should that be changed to /org/mate/caja-open-terminal/ and org.mate.caja-open-terminal?
