### PR TITLE
keyboard shifts again

### DIFF
--- a/po/af.po
+++ b/po/af.po
@@ -418,14 +418,14 @@ msgstr "K_arakter:"
 #. Accessible name for the shift left button
 #. Tooltip for the shift left button
 #: ../data/buttons-programming.ui.h:23 ../src/math-buttons.c:250
-msgid "Shift Left"
-msgstr "Skuif links"
+msgid "Shift Left [<<]"
+msgstr "Skuif links [<<]"
 
 #. Accessible name for the shift right button
 #. Tooltip for the shift right button
 #: ../data/buttons-programming.ui.h:25 ../src/math-buttons.c:253
-msgid "Shift Right"
-msgstr "Skuif regs"
+msgid "Shift Right [>>]"
+msgstr "Skuif regs [>>]"
 
 #. Accessible name for the insert character button
 #: ../data/buttons-programming.ui.h:27

--- a/po/ar.po
+++ b/po/ar.po
@@ -422,14 +422,14 @@ msgstr "م_حرف:"
 #. Accessible name for the shift left button
 #. Tooltip for the shift left button
 #: ../data/buttons-programming.ui.h:23 ../src/math-buttons.c:250
-msgid "Shift Left"
-msgstr "نقل لليسار"
+msgid "Shift Left [<<]"
+msgstr "نقل لليسار [<<]"
 
 #. Accessible name for the shift right button
 #. Tooltip for the shift right button
 #: ../data/buttons-programming.ui.h:25 ../src/math-buttons.c:253
-msgid "Shift Right"
-msgstr "نقل لليمين"
+msgid "Shift Right [>>]"
+msgstr "نقل لليمين [>>]"
 
 #. Accessible name for the insert character button
 #: ../data/buttons-programming.ui.h:27

--- a/po/as.po
+++ b/po/as.po
@@ -420,14 +420,14 @@ msgstr "আখৰ (_a):"
 #. Accessible name for the shift left button
 #. Tooltip for the shift left button
 #: ../data/buttons-programming.ui.h:23 ../src/math-buttons.c:250
-msgid "Shift Left"
-msgstr "বাঁওফালে স্থানান্তৰ কৰক"
+msgid "Shift Left [<<]"
+msgstr "বাঁওফালে স্থানান্তৰ কৰক [<<]"
 
 #. Accessible name for the shift right button
 #. Tooltip for the shift right button
 #: ../data/buttons-programming.ui.h:25 ../src/math-buttons.c:253
-msgid "Shift Right"
-msgstr "সোঁফালে স্থানান্তৰ কৰক"
+msgid "Shift Right [>>]"
+msgstr "সোঁফালে স্থানান্তৰ কৰক [>>]"
 
 #. Accessible name for the insert character button
 #: ../data/buttons-programming.ui.h:27

--- a/po/ast.po
+++ b/po/ast.po
@@ -418,14 +418,14 @@ msgstr "C_arauter"
 #. Accessible name for the shift left button
 #. Tooltip for the shift left button
 #: ../data/buttons-programming.ui.h:23 ../src/math-buttons.c:250
-msgid "Shift Left"
-msgstr "Mayúscula esquierda"
+msgid "Shift Left [<<]"
+msgstr "Mayúscula esquierda [<<]"
 
 #. Accessible name for the shift right button
 #. Tooltip for the shift right button
 #: ../data/buttons-programming.ui.h:25 ../src/math-buttons.c:253
-msgid "Shift Right"
-msgstr "Mayúscula drecha"
+msgid "Shift Right [>>]"
+msgstr "Mayúscula drecha [>>]"
 
 #. Accessible name for the insert character button
 #: ../data/buttons-programming.ui.h:27

--- a/po/bg.po
+++ b/po/bg.po
@@ -420,14 +420,14 @@ msgstr "_Знак:"
 #. Accessible name for the shift left button
 #. Tooltip for the shift left button
 #: ../data/buttons-programming.ui.h:23 ../src/math-buttons.c:250
-msgid "Shift Left"
-msgstr "Отместване наляво"
+msgid "Shift Left [<<]"
+msgstr "Отместване наляво [<<]"
 
 #. Accessible name for the shift right button
 #. Tooltip for the shift right button
 #: ../data/buttons-programming.ui.h:25 ../src/math-buttons.c:253
-msgid "Shift Right"
-msgstr "Отместване надясно"
+msgid "Shift Right [>>]"
+msgstr "Отместване надясно [>>]"
 
 #. Accessible name for the insert character button
 #: ../data/buttons-programming.ui.h:27

--- a/po/bn.po
+++ b/po/bn.po
@@ -422,14 +422,14 @@ msgstr "অক্ষর: (_a)"
 #. Accessible name for the shift left button
 #. Tooltip for the shift left button
 #: ../data/buttons-programming.ui.h:23 ../src/math-buttons.c:250
-msgid "Shift Left"
-msgstr "বামে সরান"
+msgid "Shift Left [<<]"
+msgstr "বামে সরান [<<]"
 
 #. Accessible name for the shift right button
 #. Tooltip for the shift right button
 #: ../data/buttons-programming.ui.h:25 ../src/math-buttons.c:253
-msgid "Shift Right"
-msgstr "ডানে সরান"
+msgid "Shift Right [>>]"
+msgstr "ডানে সরান [>>]"
 
 #. Accessible name for the insert character button
 #: ../data/buttons-programming.ui.h:27

--- a/po/ca.po
+++ b/po/ca.po
@@ -418,14 +418,14 @@ msgstr "C_aràcter:"
 #. Accessible name for the shift left button
 #. Tooltip for the shift left button
 #: ../data/buttons-programming.ui.h:23 ../src/math-buttons.c:250
-msgid "Shift Left"
-msgstr "Desplaça a l'esquerra"
+msgid "Shift Left [<<]"
+msgstr "Desplaça a l'esquerra [<<]"
 
 #. Accessible name for the shift right button
 #. Tooltip for the shift right button
 #: ../data/buttons-programming.ui.h:25 ../src/math-buttons.c:253
-msgid "Shift Right"
-msgstr "Desplaça a la dreta"
+msgid "Shift Right [>>]"
+msgstr "Desplaça a la dreta [>>]"
 
 #. Accessible name for the insert character button
 #: ../data/buttons-programming.ui.h:27

--- a/po/da.po
+++ b/po/da.po
@@ -418,14 +418,14 @@ msgstr "_Tegn:"
 #. Accessible name for the shift left button
 #. Tooltip for the shift left button
 #: ../data/buttons-programming.ui.h:23 ../src/math-buttons.c:250
-msgid "Shift Left"
-msgstr "Forskyd til venstre"
+msgid "Shift Left [<<]"
+msgstr "Forskyd til venstre [<<]"
 
 #. Accessible name for the shift right button
 #. Tooltip for the shift right button
 #: ../data/buttons-programming.ui.h:25 ../src/math-buttons.c:253
-msgid "Shift Right"
-msgstr "Forskyd til højre"
+msgid "Shift Right [>>]"
+msgstr "Forskyd til højre [>>]"
 
 #. Accessible name for the insert character button
 #: ../data/buttons-programming.ui.h:27

--- a/po/de.po
+++ b/po/de.po
@@ -426,14 +426,14 @@ msgstr "_Zeichen:"
 #. Accessible name for the shift left button
 #. Tooltip for the shift left button
 #: ../data/buttons-programming.ui.h:23 ../src/math-buttons.c:250
-msgid "Shift Left"
-msgstr "Nach links verschieben"
+msgid "Shift Left [<<]"
+msgstr "Nach links verschieben [<<]"
 
 #. Accessible name for the shift right button
 #. Tooltip for the shift right button
 #: ../data/buttons-programming.ui.h:25 ../src/math-buttons.c:253
-msgid "Shift Right"
-msgstr "Nach rechts verschieben"
+msgid "Shift Right [>>]"
+msgstr "Nach rechts verschieben [>>]"
 
 #. Accessible name for the insert character button
 #: ../data/buttons-programming.ui.h:27

--- a/po/en@shaw.po
+++ b/po/en@shaw.po
@@ -422,14 +422,14 @@ msgstr "𐑦𐑯𐑕𐑻𐑑 𐑒𐑨𐑮𐑩𐑒𐑑𐑼 𐑒𐑴𐑛"
 #. Accessible name for the shift left button
 #. Tooltip for the shift left button
 #: ../data/buttons-programming.ui.h:28 ../src/math-buttons.c:243
-msgid "Shift Left"
-msgstr "𐑖𐑦𐑓𐑑 𐑤𐑧𐑓𐑑"
+msgid "Shift Left [<<]"
+msgstr "𐑖𐑦𐑓𐑑 𐑤𐑧𐑓𐑑 [<<]"
 
 #. Accessible name for the shift right button
 #. Tooltip for the shift right button
 #: ../data/buttons-programming.ui.h:30 ../src/math-buttons.c:246
-msgid "Shift Right"
-msgstr "𐑖𐑦𐑓𐑑 𐑮𐑲𐑑"
+msgid "Shift Right [>>]"
+msgstr "𐑖𐑦𐑓𐑑 𐑮𐑲𐑑 [>>]"
 
 #. Insert ASCII dialog: Button to insert selected character
 #: ../data/buttons-programming.ui.h:38

--- a/po/en_AU.po
+++ b/po/en_AU.po
@@ -416,14 +416,14 @@ msgstr "Ch_aracter:"
 #. Accessible name for the shift left button
 #. Tooltip for the shift left button
 #: ../data/buttons-programming.ui.h:23 ../src/math-buttons.c:250
-msgid "Shift Left"
-msgstr "Shift Left"
+msgid "Shift Left [<<]"
+msgstr "Shift Left [<<]"
 
 #. Accessible name for the shift right button
 #. Tooltip for the shift right button
 #: ../data/buttons-programming.ui.h:25 ../src/math-buttons.c:253
-msgid "Shift Right"
-msgstr "Shift Right"
+msgid "Shift Right [>>]"
+msgstr "Shift Right [>>]"
 
 #. Accessible name for the insert character button
 #: ../data/buttons-programming.ui.h:27

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -418,14 +418,14 @@ msgstr "Ch_aracter:"
 #. Accessible name for the shift left button
 #. Tooltip for the shift left button
 #: ../data/buttons-programming.ui.h:23 ../src/math-buttons.c:250
-msgid "Shift Left"
-msgstr "Shift Left"
+msgid "Shift Left [<<]"
+msgstr "Shift Left [<<]"
 
 #. Accessible name for the shift right button
 #. Tooltip for the shift right button
 #: ../data/buttons-programming.ui.h:25 ../src/math-buttons.c:253
-msgid "Shift Right"
-msgstr "Shift Right"
+msgid "Shift Right [>>]"
+msgstr "Shift Right [>>]"
 
 #. Accessible name for the insert character button
 #: ../data/buttons-programming.ui.h:27

--- a/po/eo.po
+++ b/po/eo.po
@@ -422,14 +422,14 @@ msgstr "_Signo:"
 #. Accessible name for the shift left button
 #. Tooltip for the shift left button
 #: ../data/buttons-programming.ui.h:23 ../src/math-buttons.c:250
-msgid "Shift Left"
-msgstr "Ŝovi maldekstren"
+msgid "Shift Left [<<]"
+msgstr "Ŝovi maldekstren [<<]"
 
 #. Accessible name for the shift right button
 #. Tooltip for the shift right button
 #: ../data/buttons-programming.ui.h:25 ../src/math-buttons.c:253
-msgid "Shift Right"
-msgstr "Ŝovi dekstren"
+msgid "Shift Right [>>]"
+msgstr "Ŝovi dekstren [>>]"
 
 #. Accessible name for the insert character button
 #: ../data/buttons-programming.ui.h:27

--- a/po/eu.po
+++ b/po/eu.po
@@ -420,14 +420,14 @@ msgstr "_Karakterea:"
 #. Accessible name for the shift left button
 #. Tooltip for the shift left button
 #: ../data/buttons-programming.ui.h:23 ../src/math-buttons.c:250
-msgid "Shift Left"
-msgstr "Lerratu ezkerrera"
+msgid "Shift Left [<<]"
+msgstr "Lerratu ezkerrera [<<]"
 
 #. Accessible name for the shift right button
 #. Tooltip for the shift right button
 #: ../data/buttons-programming.ui.h:25 ../src/math-buttons.c:253
-msgid "Shift Right"
-msgstr "Lerratu eskuinera"
+msgid "Shift Right [>>]"
+msgstr "Lerratu eskuinera [>>]"
 
 #. Accessible name for the insert character button
 #: ../data/buttons-programming.ui.h:27

--- a/po/fa.po
+++ b/po/fa.po
@@ -418,14 +418,14 @@ msgstr "نوی_سه:"
 #. Accessible name for the shift left button
 #. Tooltip for the shift left button
 #: ../data/buttons-programming.ui.h:23 ../src/math-buttons.c:250
-msgid "Shift Left"
-msgstr "تبدیل به چپ"
+msgid "Shift Left [<<]"
+msgstr "تبدیل به چپ [<<]"
 
 #. Accessible name for the shift right button
 #. Tooltip for the shift right button
 #: ../data/buttons-programming.ui.h:25 ../src/math-buttons.c:253
-msgid "Shift Right"
-msgstr "تبدیل به راست"
+msgid "Shift Right [>>]"
+msgstr "تبدیل به راست [>>]"
 
 #. Accessible name for the insert character button
 #: ../data/buttons-programming.ui.h:27

--- a/po/fr.po
+++ b/po/fr.po
@@ -424,14 +424,14 @@ msgstr "_Caractère :"
 #. Accessible name for the shift left button
 #. Tooltip for the shift left button
 #: ../data/buttons-programming.ui.h:23 ../src/math-buttons.c:250
-msgid "Shift Left"
-msgstr "Maj. gauche"
+msgid "Shift Left [<<]"
+msgstr "Maj. gauche [<<]"
 
 #. Accessible name for the shift right button
 #. Tooltip for the shift right button
 #: ../data/buttons-programming.ui.h:25 ../src/math-buttons.c:253
-msgid "Shift Right"
-msgstr "Maj. droite"
+msgid "Shift Right [>>]"
+msgstr "Maj. droite [>>]"
 
 #. Accessible name for the insert character button
 #: ../data/buttons-programming.ui.h:27

--- a/po/gl.po
+++ b/po/gl.po
@@ -428,14 +428,14 @@ msgstr "C_arácter:"
 #. Accessible name for the shift left button
 #. Tooltip for the shift left button
 #: ../data/buttons-programming.ui.h:23 ../src/math-buttons.c:250
-msgid "Shift Left"
-msgstr "Desprazar á esquerda"
+msgid "Shift Left [<<]"
+msgstr "Desprazar á esquerda [<<]"
 
 #. Accessible name for the shift right button
 #. Tooltip for the shift right button
 #: ../data/buttons-programming.ui.h:25 ../src/math-buttons.c:253
-msgid "Shift Right"
-msgstr "Desprazar á dereita"
+msgid "Shift Right [>>]"
+msgstr "Desprazar á dereita [>>]"
 
 #. Accessible name for the insert character button
 #: ../data/buttons-programming.ui.h:27

--- a/po/gu.po
+++ b/po/gu.po
@@ -418,14 +418,14 @@ msgstr "અક્ષર (_a):"
 #. Accessible name for the shift left button
 #. Tooltip for the shift left button
 #: ../data/buttons-programming.ui.h:23 ../src/math-buttons.c:250
-msgid "Shift Left"
-msgstr "Shift Left"
+msgid "Shift Left [<<]"
+msgstr "Shift Left [<<]"
 
 #. Accessible name for the shift right button
 #. Tooltip for the shift right button
 #: ../data/buttons-programming.ui.h:25 ../src/math-buttons.c:253
-msgid "Shift Right"
-msgstr "Shift Right"
+msgid "Shift Right [>>]"
+msgstr "Shift Right [>>]"
 
 #. Accessible name for the insert character button
 #: ../data/buttons-programming.ui.h:27

--- a/po/hu.po
+++ b/po/hu.po
@@ -420,14 +420,14 @@ msgstr "K_arakter:"
 #. Accessible name for the shift left button
 #. Tooltip for the shift left button
 #: ../data/buttons-programming.ui.h:23 ../src/math-buttons.c:250
-msgid "Shift Left"
-msgstr "Balra csúsztatás"
+msgid "Shift Left [<<]"
+msgstr "Balra csúsztatás [<<]"
 
 #. Accessible name for the shift right button
 #. Tooltip for the shift right button
 #: ../data/buttons-programming.ui.h:25 ../src/math-buttons.c:253
-msgid "Shift Right"
-msgstr "Jobbra csúsztatás"
+msgid "Shift Right [>>]"
+msgstr "Jobbra csúsztatás [>>]"
 
 #. Accessible name for the insert character button
 #: ../data/buttons-programming.ui.h:27

--- a/po/id.po
+++ b/po/id.po
@@ -422,14 +422,14 @@ msgstr "K_arakter:"
 #. Accessible name for the shift left button
 #. Tooltip for the shift left button
 #: ../data/buttons-programming.ui.h:23 ../src/math-buttons.c:250
-msgid "Shift Left"
-msgstr "Geser Kiri"
+msgid "Shift Left [<<]"
+msgstr "Geser Kiri [<<]"
 
 #. Accessible name for the shift right button
 #. Tooltip for the shift right button
 #: ../data/buttons-programming.ui.h:25 ../src/math-buttons.c:253
-msgid "Shift Right"
-msgstr "Geser Kanan"
+msgid "Shift Right [>>]"
+msgstr "Geser Kanan [>>]"
 
 #. Accessible name for the insert character button
 #: ../data/buttons-programming.ui.h:27

--- a/po/kk.po
+++ b/po/kk.po
@@ -416,14 +416,14 @@ msgstr ""
 #. Accessible name for the shift left button
 #. Tooltip for the shift left button
 #: ../data/buttons-programming.ui.h:23 ../src/math-buttons.c:250
-msgid "Shift Left"
-msgstr ""
+msgid "Shift Left [<<]"
+msgstr " [<<]"
 
 #. Accessible name for the shift right button
 #. Tooltip for the shift right button
 #: ../data/buttons-programming.ui.h:25 ../src/math-buttons.c:253
-msgid "Shift Right"
-msgstr ""
+msgid "Shift Right [>>]"
+msgstr " [>>]"
 
 #. Accessible name for the insert character button
 #: ../data/buttons-programming.ui.h:27

--- a/po/kn.po
+++ b/po/kn.po
@@ -416,14 +416,14 @@ msgstr "ಅಕ್ಷರ(_a):"
 #. Accessible name for the shift left button
 #. Tooltip for the shift left button
 #: ../data/buttons-programming.ui.h:23 ../src/math-buttons.c:250
-msgid "Shift Left"
-msgstr "ಶಿಫ್ಟ್‍ ಎಡ"
+msgid "Shift Left [<<]"
+msgstr "ಶಿಫ್ಟ್‍ ಎಡ [<<]"
 
 #. Accessible name for the shift right button
 #. Tooltip for the shift right button
 #: ../data/buttons-programming.ui.h:25 ../src/math-buttons.c:253
-msgid "Shift Right"
-msgstr "ಶಿಫ್ಟ್‍ ಬಲ"
+msgid "Shift Right [>>]"
+msgstr "ಶಿಫ್ಟ್‍ ಬಲ [>>]"
 
 #. Accessible name for the insert character button
 #: ../data/buttons-programming.ui.h:27

--- a/po/ky.po
+++ b/po/ky.po
@@ -416,14 +416,14 @@ msgstr "С_имвол:"
 #. Accessible name for the shift left button
 #. Tooltip for the shift left button
 #: ../data/buttons-programming.ui.h:23 ../src/math-buttons.c:250
-msgid "Shift Left"
-msgstr "Солго жылдыруу"
+msgid "Shift Left [<<]"
+msgstr "Солго жылдыруу [<<]"
 
 #. Accessible name for the shift right button
 #. Tooltip for the shift right button
 #: ../data/buttons-programming.ui.h:25 ../src/math-buttons.c:253
-msgid "Shift Right"
-msgstr "Оңго жылдыруу"
+msgid "Shift Right [>>]"
+msgstr "Оңго жылдыруу [>>]"
 
 #. Accessible name for the insert character button
 #: ../data/buttons-programming.ui.h:27

--- a/po/lt.po
+++ b/po/lt.po
@@ -422,14 +422,14 @@ msgstr "_Simbolis:"
 #. Accessible name for the shift left button
 #. Tooltip for the shift left button
 #: ../data/buttons-programming.ui.h:23 ../src/math-buttons.c:250
-msgid "Shift Left"
-msgstr "Postūmis kairiau"
+msgid "Shift Left [<<]"
+msgstr "Postūmis kairiau [<<]"
 
 #. Accessible name for the shift right button
 #. Tooltip for the shift right button
 #: ../data/buttons-programming.ui.h:25 ../src/math-buttons.c:253
-msgid "Shift Right"
-msgstr "Postūmis dešiniau"
+msgid "Shift Right [>>]"
+msgstr "Postūmis dešiniau [>>]"
 
 #. Accessible name for the insert character button
 #: ../data/buttons-programming.ui.h:27

--- a/po/mk.po
+++ b/po/mk.po
@@ -422,14 +422,14 @@ msgstr "Зн_ак:"
 #. Accessible name for the shift left button
 #. Tooltip for the shift left button
 #: ../data/buttons-programming.ui.h:23 ../src/math-buttons.c:250
-msgid "Shift Left"
-msgstr "Помести на лево"
+msgid "Shift Left [<<]"
+msgstr "Помести на лево [<<]"
 
 #. Accessible name for the shift right button
 #. Tooltip for the shift right button
 #: ../data/buttons-programming.ui.h:25 ../src/math-buttons.c:253
-msgid "Shift Right"
-msgstr "Помести на десно"
+msgid "Shift Right [>>]"
+msgstr "Помести на десно [>>]"
 
 #. Accessible name for the insert character button
 #: ../data/buttons-programming.ui.h:27

--- a/po/mr.po
+++ b/po/mr.po
@@ -418,14 +418,14 @@ msgstr "अक्षर (_a):"
 #. Accessible name for the shift left button
 #. Tooltip for the shift left button
 #: ../data/buttons-programming.ui.h:23 ../src/math-buttons.c:250
-msgid "Shift Left"
-msgstr "शिफ्ट डावी"
+msgid "Shift Left [<<]"
+msgstr "शिफ्ट डावी [<<]"
 
 #. Accessible name for the shift right button
 #. Tooltip for the shift right button
 #: ../data/buttons-programming.ui.h:25 ../src/math-buttons.c:253
-msgid "Shift Right"
-msgstr "शिफ्ट उजवी"
+msgid "Shift Right [>>]"
+msgstr "शिफ्ट उजवी [>>]"
 
 #. Accessible name for the insert character button
 #: ../data/buttons-programming.ui.h:27

--- a/po/nl.po
+++ b/po/nl.po
@@ -422,14 +422,14 @@ msgstr "_Teken:"
 #. Accessible name for the shift left button
 #. Tooltip for the shift left button
 #: ../data/buttons-programming.ui.h:23 ../src/math-buttons.c:250
-msgid "Shift Left"
-msgstr "Shift links"
+msgid "Shift Left [<<]"
+msgstr "Shift links [<<]"
 
 #. Accessible name for the shift right button
 #. Tooltip for the shift right button
 #: ../data/buttons-programming.ui.h:25 ../src/math-buttons.c:253
-msgid "Shift Right"
-msgstr "Shift rechts"
+msgid "Shift Right [>>]"
+msgstr "Shift rechts [>>]"
 
 #. Accessible name for the insert character button
 #: ../data/buttons-programming.ui.h:27

--- a/po/or.po
+++ b/po/or.po
@@ -416,14 +416,14 @@ msgstr "ଅକ୍ଷର (_a):"
 #. Accessible name for the shift left button
 #. Tooltip for the shift left button
 #: ../data/buttons-programming.ui.h:23 ../src/math-buttons.c:250
-msgid "Shift Left"
-msgstr "ବାମପାଖକୁ ବଦଳାନ୍ତୁ"
+msgid "Shift Left [<<]"
+msgstr "ବାମପାଖକୁ ବଦଳାନ୍ତୁ [<<]"
 
 #. Accessible name for the shift right button
 #. Tooltip for the shift right button
 #: ../data/buttons-programming.ui.h:25 ../src/math-buttons.c:253
-msgid "Shift Right"
-msgstr "ଡାହାଣକୁ ଘୁଞ୍ଚାଅ"
+msgid "Shift Right [>>]"
+msgstr "ଡାହାଣକୁ ଘୁଞ୍ଚାଅ [>>]"
 
 #. Accessible name for the insert character button
 #: ../data/buttons-programming.ui.h:27

--- a/po/pt.po
+++ b/po/pt.po
@@ -418,14 +418,14 @@ msgstr "C_aracter:"
 #. Accessible name for the shift left button
 #. Tooltip for the shift left button
 #: ../data/buttons-programming.ui.h:23 ../src/math-buttons.c:250
-msgid "Shift Left"
-msgstr "Deslocar à Esquerda"
+msgid "Shift Left [<<]"
+msgstr "Deslocar à Esquerda [<<]"
 
 #. Accessible name for the shift right button
 #. Tooltip for the shift right button
 #: ../data/buttons-programming.ui.h:25 ../src/math-buttons.c:253
-msgid "Shift Right"
-msgstr "Deslocar à Direita"
+msgid "Shift Right [>>]"
+msgstr "Deslocar à Direita [>>]"
 
 #. Accessible name for the insert character button
 #: ../data/buttons-programming.ui.h:27

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -428,14 +428,14 @@ msgstr "C_aractere:"
 #. Accessible name for the shift left button
 #. Tooltip for the shift left button
 #: ../data/buttons-programming.ui.h:23 ../src/math-buttons.c:250
-msgid "Shift Left"
-msgstr "Mover para a esquerda"
+msgid "Shift Left [<<]"
+msgstr "Mover para a esquerda [<<]"
 
 #. Accessible name for the shift right button
 #. Tooltip for the shift right button
 #: ../data/buttons-programming.ui.h:25 ../src/math-buttons.c:253
-msgid "Shift Right"
-msgstr "Mover para a direita"
+msgid "Shift Right [>>]"
+msgstr "Mover para a direita [>>]"
 
 #. Accessible name for the insert character button
 #: ../data/buttons-programming.ui.h:27

--- a/po/ru.po
+++ b/po/ru.po
@@ -424,14 +424,14 @@ msgstr "С_имвол:"
 #. Accessible name for the shift left button
 #. Tooltip for the shift left button
 #: ../data/buttons-programming.ui.h:23 ../src/math-buttons.c:250
-msgid "Shift Left"
-msgstr "Сдвинуть влево"
+msgid "Shift Left [<<]"
+msgstr "Сдвинуть влево [<<]"
 
 #. Accessible name for the shift right button
 #. Tooltip for the shift right button
 #: ../data/buttons-programming.ui.h:25 ../src/math-buttons.c:253
-msgid "Shift Right"
-msgstr "Сдвинуть вправо"
+msgid "Shift Right [>>]"
+msgstr "Сдвинуть вправо [>>]"
 
 #. Accessible name for the insert character button
 #: ../data/buttons-programming.ui.h:27

--- a/po/sl.po
+++ b/po/sl.po
@@ -416,14 +416,14 @@ msgstr "_Znak:"
 #. Accessible name for the shift left button
 #. Tooltip for the shift left button
 #: ../data/buttons-programming.ui.h:23 ../src/math-buttons.c:250
-msgid "Shift Left"
-msgstr "Premakni levo"
+msgid "Shift Left [<<]"
+msgstr "Premakni levo [<<]"
 
 #. Accessible name for the shift right button
 #. Tooltip for the shift right button
 #: ../data/buttons-programming.ui.h:25 ../src/math-buttons.c:253
-msgid "Shift Right"
-msgstr "Premakni desno"
+msgid "Shift Right [>>]"
+msgstr "Premakni desno [>>]"
 
 #. Accessible name for the insert character button
 #: ../data/buttons-programming.ui.h:27

--- a/po/sr.po
+++ b/po/sr.po
@@ -418,14 +418,14 @@ msgstr "_Знак:"
 #. Accessible name for the shift left button
 #. Tooltip for the shift left button
 #: ../data/buttons-programming.ui.h:23 ../src/math-buttons.c:250
-msgid "Shift Left"
-msgstr "Помери улево"
+msgid "Shift Left [<<]"
+msgstr "Помери улево [<<]"
 
 #. Accessible name for the shift right button
 #. Tooltip for the shift right button
 #: ../data/buttons-programming.ui.h:25 ../src/math-buttons.c:253
-msgid "Shift Right"
-msgstr "Помери удесно"
+msgid "Shift Right [>>]"
+msgstr "Помери удесно [>>]"
 
 #. Accessible name for the insert character button
 #: ../data/buttons-programming.ui.h:27

--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -418,14 +418,14 @@ msgstr "_Znak:"
 #. Accessible name for the shift left button
 #. Tooltip for the shift left button
 #: ../data/buttons-programming.ui.h:23 ../src/math-buttons.c:250
-msgid "Shift Left"
-msgstr "Pomeri ulevo"
+msgid "Shift Left [<<]"
+msgstr "Pomeri ulevo [<<]"
 
 #. Accessible name for the shift right button
 #. Tooltip for the shift right button
 #: ../data/buttons-programming.ui.h:25 ../src/math-buttons.c:253
-msgid "Shift Right"
-msgstr "Pomeri udesno"
+msgid "Shift Right [>>]"
+msgstr "Pomeri udesno [>>]"
 
 #. Accessible name for the insert character button
 #: ../data/buttons-programming.ui.h:27

--- a/po/ta.po
+++ b/po/ta.po
@@ -422,14 +422,14 @@ msgstr "_a எழுத்து:"
 #. Accessible name for the shift left button
 #. Tooltip for the shift left button
 #: ../data/buttons-programming.ui.h:23 ../src/math-buttons.c:250
-msgid "Shift Left"
-msgstr "இடது பக்கம் நகர்த்துக."
+msgid "Shift Left [<<]"
+msgstr "இடது பக்கம் நகர்த்துக. [<<]"
 
 #. Accessible name for the shift right button
 #. Tooltip for the shift right button
 #: ../data/buttons-programming.ui.h:25 ../src/math-buttons.c:253
-msgid "Shift Right"
-msgstr "வலது பக்கம் நகர்த்துக"
+msgid "Shift Right [>>]"
+msgstr "வலது பக்கம் நகர்த்துக [>>]"
 
 #. Accessible name for the insert character button
 #: ../data/buttons-programming.ui.h:27

--- a/po/vi.po
+++ b/po/vi.po
@@ -416,14 +416,14 @@ msgstr "_Ký tự:"
 #. Accessible name for the shift left button
 #. Tooltip for the shift left button
 #: ../data/buttons-programming.ui.h:23 ../src/math-buttons.c:250
-msgid "Shift Left"
-msgstr "Dịch trái"
+msgid "Shift Left [<<]"
+msgstr "Dịch trái [<<]"
 
 #. Accessible name for the shift right button
 #. Tooltip for the shift right button
 #: ../data/buttons-programming.ui.h:25 ../src/math-buttons.c:253
-msgid "Shift Right"
-msgstr "Dịch phải"
+msgid "Shift Right [>>]"
+msgstr "Dịch phải [>>]"
 
 #. Accessible name for the insert character button
 #: ../data/buttons-programming.ui.h:27

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -426,14 +426,14 @@ msgstr "字符(_A)："
 #. Accessible name for the shift left button
 #. Tooltip for the shift left button
 #: ../data/buttons-programming.ui.h:23 ../src/math-buttons.c:250
-msgid "Shift Left"
-msgstr "左移"
+msgid "Shift Left [<<]"
+msgstr "左移 [<<]"
 
 #. Accessible name for the shift right button
 #. Tooltip for the shift right button
 #: ../data/buttons-programming.ui.h:25 ../src/math-buttons.c:253
-msgid "Shift Right"
-msgstr "右移"
+msgid "Shift Right [>>]"
+msgstr "右移 [>>]"
 
 #. Accessible name for the insert character button
 #: ../data/buttons-programming.ui.h:27

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -418,14 +418,14 @@ msgstr "字符(_A)："
 #. Accessible name for the shift left button
 #. Tooltip for the shift left button
 #: ../data/buttons-programming.ui.h:23 ../src/math-buttons.c:250
-msgid "Shift Left"
-msgstr "左移"
+msgid "Shift Left [<<]"
+msgstr "左移 [<<]"
 
 #. Accessible name for the shift right button
 #. Tooltip for the shift right button
 #: ../data/buttons-programming.ui.h:25 ../src/math-buttons.c:253
-msgid "Shift Right"
-msgstr "右移"
+msgid "Shift Right [>>]"
+msgstr "右移 [>>]"
 
 #. Accessible name for the insert character button
 #: ../data/buttons-programming.ui.h:27

--- a/src/math-buttons.c
+++ b/src/math-buttons.c
@@ -247,10 +247,10 @@ static ButtonData button_data[] = {
       N_("Undo [Ctrl+Z]")},
     {"shift_left", NULL, ACTION,
       /* Tooltip for the shift left button */
-      N_("Shift Left")},  
+      N_("Shift Left [<<]")},
     {"shift_right", NULL, ACTION,
       /* Tooltip for the shift right button */
-      N_("Shift Right")},  
+      N_("Shift Right [>>]")},
     {"finc_compounding_term", NULL, FUNCTION,
       /* Tooltip for the compounding term button */
       N_("Compounding Term")},


### PR DESCRIPTION
hi,

keyboard shifts are broken apparently: the formulas are not parsed correctly anymore (e.g. "1<<2" results in "Malformed expression"). I can't build all previous versions on my machine and can't tell you which commit broke it, but 6b24c91d3aa81fdb99500c8c2c12f830fabaefb6 removed some parts of my patch. OTOH all needed parser/lexer code is not touched by it. Most of my changes that were deleted by that commit were reapplied in 4531aea8ae8b2253218e0c6734618823003d2408. The only yet missing parts are the tooltip characters which are included in this pull request, but of course they don't fix the parsing problem.
