### PR TITLE
building: bump required glib and gtk+ versions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -19,9 +19,9 @@ dnl ###########################################################################
 dnl Dependencies
 dnl ###########################################################################
 
-GLIB_REQUIRED=2.36.0
+GLIB_REQUIRED=2.50.0
 GIO_REQUIRED=2.36.0
-GTK_REQUIRED=3.14.0
+GTK_REQUIRED=3.22.0
 
 PKG_CHECK_MODULES(MATE_CALC, [
     gtk+-3.0 >= $GTK_REQUIRED

--- a/src/math-window.c
+++ b/src/math-window.c
@@ -198,20 +198,12 @@ static void redo_cb(GtkWidget *widget, MathWindow *window)
 
 static void help_cb(GtkWidget *widget, MathWindow *window)
 {
-#if GTK_CHECK_VERSION (3, 22, 0)
     GError *error = NULL;
 
     gtk_show_uri_on_window(GTK_WINDOW(window),
                            "help:mate-calc",
                            gtk_get_current_event_time(),
                            &error);
-#else
-    GdkScreen  *screen;
-    GError *error = NULL;
-
-    screen = gtk_widget_get_screen(GTK_WIDGET(window));
-    gtk_show_uri(screen, "help:mate-calc", gtk_get_current_event_time(), &error);
-#endif
 
     if (error != NULL)
     {


### PR DESCRIPTION
and drop old bits

Tested with:
grep -nr GTK_CHECK_VERSION *
grep -nr GLIB_CHECK_VERSION *
