### PR TITLE
changed accuracy in data/org.mate.calc.gschema.xml.in to 15

### DIFF
--- a/data/org.mate.calc.gschema.xml.in
+++ b/data/org.mate.calc.gschema.xml.in
@@ -20,8 +20,8 @@
 
   <schema path="/org/mate/calc/" id="org.mate.calc" gettext-domain="mate-calc">
     <key type="i" name="accuracy">
-      <default>9</default>
-      <range min="0" max="9"/>
+      <default>15</default>
+      <range min="0" max="15"/>
       <summary>Accuracy value</summary>
       <description>The number of digits displayed after the numeric point</description>
     </key>


### PR DESCRIPTION
Several issues were opened because the accuracy was set too low. Changed it to 15, but will provide a slider to set the accuracy in the settings later.