### PR TITLE
ui files: add missing icons in titles to dialogs

### DIFF
--- a/data/buttons-financial.ui
+++ b/data/buttons-financial.ui
@@ -8,6 +8,7 @@
     <property name="title" translatable="yes" comments="Title of Compounding Term dialog">Compounding Term</property>
     <property name="resizable">False</property>
     <property name="type_hint">dialog</property>
+    <property name="icon_name">accessories-calculator</property>
     <signal name="response" handler="finc_response_cb" swapped="no"/>
     <child>
       <placeholder/>
@@ -190,6 +191,7 @@
     <property name="title" translatable="yes" comments="Title of Double-Declining Depreciation dialog">Double-Declining Depreciation</property>
     <property name="resizable">False</property>
     <property name="type_hint">dialog</property>
+    <property name="icon_name">accessories-calculator</property>
     <signal name="response" handler="finc_response_cb" swapped="no"/>
     <child>
       <placeholder/>
@@ -372,6 +374,7 @@
     <property name="title" translatable="yes" comments="Title of Future Value dialog">Future Value</property>
     <property name="resizable">False</property>
     <property name="type_hint">dialog</property>
+    <property name="icon_name">accessories-calculator</property>
     <signal name="response" handler="finc_response_cb" swapped="no"/>
     <child>
       <placeholder/>
@@ -554,6 +557,7 @@
     <property name="title" translatable="yes" comments="Title of Gross Profit Margin dialog">Gross Profit Margin</property>
     <property name="resizable">False</property>
     <property name="type_hint">dialog</property>
+    <property name="icon_name">accessories-calculator</property>
     <signal name="response" handler="finc_response_cb" swapped="no"/>
     <child>
       <placeholder/>
@@ -706,6 +710,7 @@
     <property name="title" translatable="yes" comments="Title of Periodic Payment dialog">Periodic Payment</property>
     <property name="resizable">False</property>
     <property name="type_hint">dialog</property>
+    <property name="icon_name">accessories-calculator</property>
     <signal name="response" handler="finc_response_cb" swapped="no"/>
     <child>
       <placeholder/>
@@ -889,6 +894,7 @@
     <property name="title" translatable="yes" comments="Title of Present Value dialog">Present Value</property>
     <property name="resizable">False</property>
     <property name="type_hint">dialog</property>
+    <property name="icon_name">accessories-calculator</property>
     <signal name="response" handler="finc_response_cb" swapped="no"/>
     <child>
       <placeholder/>
@@ -1072,6 +1078,7 @@
     <property name="title" translatable="yes" comments="Title of Periodic Interest Rate dialog">Periodic Interest Rate</property>
     <property name="resizable">False</property>
     <property name="type_hint">dialog</property>
+    <property name="icon_name">accessories-calculator</property>
     <signal name="response" handler="finc_response_cb" swapped="no"/>
     <child>
       <placeholder/>
@@ -1255,6 +1262,7 @@
     <property name="title" translatable="yes" comments="Title of Straight-Line Depreciation dialog">Straight-Line Depreciation</property>
     <property name="resizable">False</property>
     <property name="type_hint">dialog</property>
+    <property name="icon_name">accessories-calculator</property>
     <signal name="response" handler="finc_response_cb" swapped="no"/>
     <child>
       <placeholder/>
@@ -1438,6 +1446,7 @@
     <property name="title" translatable="yes" comments="Title of Sum-of-the-Years'-Digits Depreciation dialog">Sum-of-the-Years'-Digits Depreciation</property>
     <property name="resizable">False</property>
     <property name="type_hint">dialog</property>
+    <property name="icon_name">accessories-calculator</property>
     <signal name="response" handler="finc_response_cb" swapped="no"/>
     <child>
       <placeholder/>
@@ -1650,6 +1659,7 @@
     <property name="title" translatable="yes" comments="Title of Payment Period dialog">Payment Period</property>
     <property name="resizable">False</property>
     <property name="type_hint">dialog</property>
+    <property name="icon_name">accessories-calculator</property>
     <signal name="response" handler="finc_response_cb" swapped="no"/>
     <child>
       <placeholder/>

--- a/data/buttons-programming.ui
+++ b/data/buttons-programming.ui
@@ -8,6 +8,7 @@
     <property name="title" translatable="yes" comments="Title of insert character code dialog">Insert Character Code</property>
     <property name="resizable">False</property>
     <property name="type_hint">dialog</property>
+    <property name="icon_name">accessories-calculator</property>
     <signal name="delete-event" handler="character_code_dialog_delete_cb" swapped="no"/>
     <signal name="response" handler="character_code_dialog_response_cb" swapped="no"/>
     <child>


### PR DESCRIPTION
How to test:

Click in these buttons and see the calculator icon in the title of dialogs.

![calc1](https://user-images.githubusercontent.com/7734191/48377135-41b70e00-e6cd-11e8-88a3-a8a0c1fb3ea5.png)

![calc2](https://user-images.githubusercontent.com/7734191/48377139-45e32b80-e6cd-11e8-95bc-3803f6e87d55.png)