### PR TITLE
Give P_Function operator a higher precedence

### DIFF
--- a/src/parser.h
+++ b/src/parser.h
@@ -23,14 +23,14 @@ typedef enum
     P_Divide=4,
     P_Not=5,
     P_Root=6,
-    P_Function=7,
-    P_Boolean=8,
-    P_Percentage=9,
+    P_Boolean=7,
+    P_Percentage=8,
     /* UnaryMinus and Power must have same precedence. */
-    P_UnaryMinus=10,
+    P_UnaryMinus=9,
     P_Power=10,
     P_Factorial=11,
-    P_NumberVariable=12,
+    P_Function=12,
+    P_NumberVariable=13,
     /* P_Depth should be always at the bottom. It stops node jumping off the current depth level. */
     P_Depth
 } Precedence;

--- a/src/parser.h
+++ b/src/parser.h
@@ -27,10 +27,10 @@ typedef enum
     P_Percentage=8,
     /* UnaryMinus and Power must have same precedence. */
     P_UnaryMinus=9,
-    P_Power=10,
-    P_Factorial=11,
-    P_Function=12,
-    P_NumberVariable=13,
+    P_Power=9,
+    P_Function=9,
+    P_Factorial=10,
+    P_NumberVariable=11,
     /* P_Depth should be always at the bottom. It stops node jumping off the current depth level. */
     P_Depth
 } Precedence;


### PR DESCRIPTION
Hi, I don't fully understand mate-calc as I'm fairly new to programming. But giving functions a higher precedence seems that it Fixes #31 and some other bugs (like -ln(e^1) now gives the correct answer -1 instead of 1+pi*i) 
I'm not sure though if it is introducing new bugs. Btw, is there a channel where newbies can get some help from the package maintainers in understanding the code?
And last but not least I've seen Gnome-Calculator uses the [GNU MPFR-Library](https://www.mpfr.org/). Wouldn't that be useful for mate-calc as well? 

EDIT: Sorry for the open/close thing, I'm still a little clumsy when it comes to handle github