### PR TITLE
mate-calc: Fix memory leak

### DIFF
--- a/src/mate-calc.c
+++ b/src/mate-calc.c
@@ -131,20 +131,24 @@ get_options(int argc, char *argv[])
         if (strcmp(arg, "-v") == 0 ||
             strcmp(arg, "--version") == 0) {
             version(progname);
+            g_free(progname);
             exit(0);
         }
         else if (strcmp(arg, "-h") == 0 ||
                  strcmp(arg, "-?") == 0 ||
                  strcmp(arg, "--help") == 0) {
             usage(progname, TRUE, FALSE);
+            g_free(progname);
             exit(0);
         }
         else if (strcmp(arg, "--help-all") == 0) {
             usage(progname, TRUE, TRUE);
+            g_free(progname);
             exit(0);
         }
         else if (strcmp(arg, "--help-gtk") == 0) {
             usage(progname, FALSE, TRUE);
+            g_free(progname);
             exit(0);
         }
         else if (strcmp(arg, "-s") == 0 ||
@@ -155,6 +159,7 @@ get_options(int argc, char *argv[])
                         /* Error printed to stderr when user uses --solve argument without an equation */
                         _("Argument --solve requires an equation to solve"));
                 fprintf(stderr, "\n");
+                g_free(progname);
                 exit(1);
             }
             else
@@ -166,9 +171,12 @@ get_options(int argc, char *argv[])
                     _("Unknown argument '%s'"), arg);
             fprintf(stderr, "\n");
             usage(progname, TRUE, FALSE);
+            g_free(progname);
             exit(1);
         }
     }
+
+    g_free(progname);
 }
 
 static void


### PR DESCRIPTION
'g_path_get_basename' needs to be freed

Fix memory leak detected by valgrind:

```
valgrind --leak-check=full mate-calc

==17452== 10 bytes in 1 blocks are definitely lost in loss record 501 of 10,243
==17452==    at 0x483577F: malloc (vg_replace_malloc.c:299)
==17452==    by 0x5657900: g_malloc (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.5800.3)
==17452==    by 0x563E84A: g_path_get_basename (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.5800.3)
==17452==    by 0x11A9E3: main (in /usr/bin/mate-calc)
```