### PR TITLE
math-buttons: avoid shifting signed 64-bit value by 63 bits

### DIFF
--- a/src/math-buttons.c
+++ b/src/math-buttons.c
@@ -388,7 +388,7 @@ update_bit_panel(MathButtons *buttons)
     for (i = 0; i < MAXBITS; i++) {
         const gchar *label;
 
-        if (bits & (1LL << (MAXBITS-i-1)))
+        if (bits & (1LLU << (MAXBITS-i-1)))
             label = " 1";
         else
             label = " 0";


### PR DESCRIPTION
Fixes cppcheck warning:

`[src/math-buttons.c:391]: (error) Shifting signed 64-bit value by 63 bits is undefined behaviour`