### PR TITLE
mp: Fix calculate result ln(e^(i*π))

### DIFF
--- a/src/mp.c
+++ b/src/mp.c
@@ -1231,7 +1231,7 @@ static void
 mp_ln_real(const MPNumber *x, MPNumber *z)
 {
     int e, k;
-    float rx, rlx;
+    double rx, rlx;
     MPNumber t1, t2;
 
     /* LOOP TO GET APPROXIMATE LN(X) USING SINGLE-PRECISION */
@@ -1250,10 +1250,10 @@ mp_ln_real(const MPNumber *x, MPNumber *z)
         /* REMOVE EXPONENT TO AVOID FLOATING-POINT OVERFLOW */
         e = t1.exponent;
         t1.exponent = 0;
-        rx = mp_cast_to_float(&t1);
+        rx = mp_cast_to_double(&t1);
         t1.exponent = e;
-        rlx = log(rx) + (float)e * log((float)MP_BASE);
-        mp_set_from_float(-(double)rlx, &t2);
+        rlx = log(rx) + e * log(MP_BASE);
+        mp_set_from_double(-(double)rlx, &t2);
 
         /* UPDATE Z AND COMPUTE ACCURATE EXP OF APPROXIMATE LOG */
         mp_subtract(z, &t2, z);


### PR DESCRIPTION
Fixes https://github.com/mate-desktop/mate-calc/issues/100

based in gnome-calculator commit:
https://gitlab.gnome.org/GNOME/gnome-calculator/commit/6eb0f2b5e6df456a97a796b35d811376a69679e0