### PR TITLE
buttons-ui: add style class "suggested-action" to result button

### DIFF
--- a/src/buttons-advanced.ui
+++ b/src/buttons-advanced.ui
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.4 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.22"/>
   <object class="GtkWindow" id="window1">
     <property name="can_focus">False</property>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
     <child>
       <object class="GtkGrid" id="button_panel">
         <property name="visible">True</property>
@@ -271,6 +274,9 @@
             <property name="receives_default">True</property>
             <property name="use_underline">True</property>
             <signal name="clicked" handler="solve_cb" swapped="no"/>
+            <style>
+              <class name="suggested-action"/>
+            </style>
           </object>
           <packing>
             <property name="left_attach">4</property>
@@ -943,9 +949,6 @@
           <placeholder/>
         </child>
       </object>
-    </child>
-    <child type="titlebar">
-      <placeholder/>
     </child>
   </object>
 </interface>

--- a/src/buttons-advanced.ui
+++ b/src/buttons-advanced.ui
@@ -291,6 +291,9 @@
             <property name="focus_on_click">False</property>
             <property name="receives_default">True</property>
             <signal name="clicked" handler="clear_cb" swapped="no"/>
+            <style>
+              <class name="destructive-action"/>
+            </style>
           </object>
           <packing>
             <property name="left_attach">5</property>

--- a/src/buttons-basic.ui
+++ b/src/buttons-basic.ui
@@ -265,6 +265,9 @@
             <property name="focus_on_click">False</property>
             <property name="receives_default">True</property>
             <signal name="clicked" handler="clear_cb" swapped="no"/>
+            <style>
+              <class name="destructive-action"/>
+            </style>
           </object>
           <packing>
             <property name="left_attach">5</property>

--- a/src/buttons-basic.ui
+++ b/src/buttons-basic.ui
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.4 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.22"/>
   <object class="GtkWindow" id="window1">
     <property name="can_focus">False</property>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
     <child>
       <object class="GtkGrid" id="button_panel">
         <property name="visible">True</property>
@@ -214,6 +217,9 @@
             <property name="receives_default">False</property>
             <property name="use_underline">True</property>
             <signal name="clicked" handler="solve_cb" swapped="no"/>
+            <style>
+              <class name="suggested-action"/>
+            </style>
           </object>
           <packing>
             <property name="left_attach">4</property>
@@ -368,9 +374,6 @@
           </packing>
         </child>
       </object>
-    </child>
-    <child type="titlebar">
-      <placeholder/>
     </child>
   </object>
 </interface>

--- a/src/buttons-financial.ui
+++ b/src/buttons-financial.ui
@@ -7,8 +7,8 @@
     <property name="border_width">6</property>
     <property name="title" translatable="yes" comments="Title of Compounding Term dialog">Compounding Term</property>
     <property name="resizable">False</property>
-    <property name="type_hint">dialog</property>
     <property name="icon_name">accessories-calculator</property>
+    <property name="type_hint">dialog</property>
     <signal name="response" handler="finc_response_cb" swapped="no"/>
     <child>
       <placeholder/>
@@ -190,8 +190,8 @@
     <property name="border_width">6</property>
     <property name="title" translatable="yes" comments="Title of Double-Declining Depreciation dialog">Double-Declining Depreciation</property>
     <property name="resizable">False</property>
-    <property name="type_hint">dialog</property>
     <property name="icon_name">accessories-calculator</property>
+    <property name="type_hint">dialog</property>
     <signal name="response" handler="finc_response_cb" swapped="no"/>
     <child>
       <placeholder/>
@@ -373,8 +373,8 @@
     <property name="border_width">6</property>
     <property name="title" translatable="yes" comments="Title of Future Value dialog">Future Value</property>
     <property name="resizable">False</property>
-    <property name="type_hint">dialog</property>
     <property name="icon_name">accessories-calculator</property>
+    <property name="type_hint">dialog</property>
     <signal name="response" handler="finc_response_cb" swapped="no"/>
     <child>
       <placeholder/>
@@ -556,8 +556,8 @@
     <property name="border_width">6</property>
     <property name="title" translatable="yes" comments="Title of Gross Profit Margin dialog">Gross Profit Margin</property>
     <property name="resizable">False</property>
-    <property name="type_hint">dialog</property>
     <property name="icon_name">accessories-calculator</property>
+    <property name="type_hint">dialog</property>
     <signal name="response" handler="finc_response_cb" swapped="no"/>
     <child>
       <placeholder/>
@@ -709,8 +709,8 @@
     <property name="border_width">6</property>
     <property name="title" translatable="yes" comments="Title of Periodic Payment dialog">Periodic Payment</property>
     <property name="resizable">False</property>
-    <property name="type_hint">dialog</property>
     <property name="icon_name">accessories-calculator</property>
+    <property name="type_hint">dialog</property>
     <signal name="response" handler="finc_response_cb" swapped="no"/>
     <child>
       <placeholder/>
@@ -893,8 +893,8 @@
     <property name="border_width">6</property>
     <property name="title" translatable="yes" comments="Title of Present Value dialog">Present Value</property>
     <property name="resizable">False</property>
-    <property name="type_hint">dialog</property>
     <property name="icon_name">accessories-calculator</property>
+    <property name="type_hint">dialog</property>
     <signal name="response" handler="finc_response_cb" swapped="no"/>
     <child>
       <placeholder/>
@@ -1077,8 +1077,8 @@
     <property name="border_width">6</property>
     <property name="title" translatable="yes" comments="Title of Periodic Interest Rate dialog">Periodic Interest Rate</property>
     <property name="resizable">False</property>
-    <property name="type_hint">dialog</property>
     <property name="icon_name">accessories-calculator</property>
+    <property name="type_hint">dialog</property>
     <signal name="response" handler="finc_response_cb" swapped="no"/>
     <child>
       <placeholder/>
@@ -1261,8 +1261,8 @@
     <property name="border_width">6</property>
     <property name="title" translatable="yes" comments="Title of Straight-Line Depreciation dialog">Straight-Line Depreciation</property>
     <property name="resizable">False</property>
-    <property name="type_hint">dialog</property>
     <property name="icon_name">accessories-calculator</property>
+    <property name="type_hint">dialog</property>
     <signal name="response" handler="finc_response_cb" swapped="no"/>
     <child>
       <placeholder/>
@@ -1445,8 +1445,8 @@
     <property name="border_width">6</property>
     <property name="title" translatable="yes" comments="Title of Sum-of-the-Years'-Digits Depreciation dialog">Sum-of-the-Years'-Digits Depreciation</property>
     <property name="resizable">False</property>
-    <property name="type_hint">dialog</property>
     <property name="icon_name">accessories-calculator</property>
+    <property name="type_hint">dialog</property>
     <signal name="response" handler="finc_response_cb" swapped="no"/>
     <child>
       <placeholder/>
@@ -1658,8 +1658,8 @@
     <property name="border_width">6</property>
     <property name="title" translatable="yes" comments="Title of Payment Period dialog">Payment Period</property>
     <property name="resizable">False</property>
-    <property name="type_hint">dialog</property>
     <property name="icon_name">accessories-calculator</property>
+    <property name="type_hint">dialog</property>
     <signal name="response" handler="finc_response_cb" swapped="no"/>
     <child>
       <placeholder/>
@@ -2104,6 +2104,9 @@
             <property name="receives_default">True</property>
             <property name="use_underline">True</property>
             <signal name="clicked" handler="solve_cb" swapped="no"/>
+            <style>
+              <class name="suggested-action"/>
+            </style>
           </object>
           <packing>
             <property name="left_attach">4</property>

--- a/src/buttons-financial.ui
+++ b/src/buttons-financial.ui
@@ -2152,6 +2152,9 @@
             <property name="focus_on_click">False</property>
             <property name="receives_default">True</property>
             <signal name="clicked" handler="clear_cb" swapped="no"/>
+            <style>
+              <class name="destructive-action"/>
+            </style>
           </object>
           <packing>
             <property name="left_attach">5</property>

--- a/src/buttons-programming.ui
+++ b/src/buttons-programming.ui
@@ -7,8 +7,8 @@
     <property name="border_width">6</property>
     <property name="title" translatable="yes" comments="Title of insert character code dialog">Insert Character Code</property>
     <property name="resizable">False</property>
-    <property name="type_hint">dialog</property>
     <property name="icon_name">accessories-calculator</property>
+    <property name="type_hint">dialog</property>
     <signal name="delete-event" handler="character_code_dialog_delete_cb" swapped="no"/>
     <signal name="response" handler="character_code_dialog_response_cb" swapped="no"/>
     <child>
@@ -2052,6 +2052,9 @@
                 <property name="receives_default">True</property>
                 <property name="use_underline">True</property>
                 <signal name="clicked" handler="solve_cb" swapped="no"/>
+                <style>
+                  <class name="suggested-action"/>
+                </style>
               </object>
               <packing>
                 <property name="left_attach">6</property>

--- a/src/buttons-programming.ui
+++ b/src/buttons-programming.ui
@@ -2070,6 +2070,9 @@
                 <property name="receives_default">True</property>
                 <property name="use_underline">True</property>
                 <signal name="clicked" handler="clear_cb" swapped="no"/>
+                <style>
+                  <class name="destructive-action"/>
+                </style>
               </object>
               <packing>
                 <property name="left_attach">6</property>


### PR DESCRIPTION
If this has an effect depends on the theme. This gives the result (=) button the colour applied to the suggested-action style class by the theme. Currently has effects in Menta theme. I saw this on gnome-calculator. Partly solves #40.

![Screenshot at 2019-05-02 00-53-03](https://user-images.githubusercontent.com/39454100/57048545-ab73a600-6c74-11e9-9b27-23f39793c7c5.png)
