### PR TITLE
mp-serializer: add missing "+" in complex numbers presentation (scientific notation)

### DIFF
--- a/src/mp-serializer.c
+++ b/src/mp-serializer.c
@@ -183,8 +183,6 @@ mp_cast_to_string(MpSerializer *serializer, const MPNumber *x, int *n_digits)
             g_string_assign(string, "");
             force_sign = FALSE;
         }
-        else if (!mp_is_negative(&x_im))
-            g_string_append(string, "+");
 
         s = g_string_sized_new(1024);
         mp_cast_to_string_real(serializer, &x_im, 10, force_sign, &n_complex_digits, s);
@@ -315,6 +313,8 @@ mp_cast_to_exponential_string(MpSerializer *serializer, const MPNumber *x, gbool
 
         if (strcmp(string->str, "0") == 0)
             g_string_assign(string, "");
+        else if (!mp_is_negative(&x_im))
+            g_string_append(string, "+");
 
         s = g_string_sized_new(1024);
         exponent = mp_cast_to_exponential_string_real(serializer, &x_im, s, eng_format, &n_complex_digits);

--- a/src/mp-serializer.c
+++ b/src/mp-serializer.c
@@ -183,6 +183,8 @@ mp_cast_to_string(MpSerializer *serializer, const MPNumber *x, int *n_digits)
             g_string_assign(string, "");
             force_sign = FALSE;
         }
+        else if (!mp_is_negative(&x_im))
+            g_string_append(string, "+");
 
         s = g_string_sized_new(1024);
         mp_cast_to_string_real(serializer, &x_im, 10, force_sign, &n_complex_digits, s);
@@ -363,8 +365,8 @@ mp_serializer_to_string(MpSerializer *serializer, const MPNumber *x)
     default:
     case MP_DISPLAY_FORMAT_AUTOMATIC:
         s0 = mp_cast_to_string(serializer, x, &n_digits);
-        if ((n_digits <= serializer->priv->leading_digits &&
-            mp_is_greater_equal(&xcmp, &cmp)) || mp_is_complex(x))
+        if (n_digits <= serializer->priv->leading_digits &&
+            mp_is_greater_equal(&xcmp, &cmp))
             return s0;
         else {
             g_free (s0);

--- a/src/mp-serializer.c
+++ b/src/mp-serializer.c
@@ -175,7 +175,7 @@ mp_cast_to_string(MpSerializer *serializer, const MPNumber *x, int *n_digits)
         GString *s;
         gboolean force_sign = TRUE;
         MPNumber x_im;
-        int n_complex_digits;
+        int n_complex_digits = 0;
 
         mp_imaginary_component(x, &x_im);
 


### PR DESCRIPTION
So that z = re(z) + im(z) will be displayed with the "+" in scientific notation.
In DISPLAY_FORMAT_AUTOMATIC I removed the workaround for this issue, so
big (or small) imaginary numbers will be displayed in scientific notation again
(as against fixed notation before) automatically.

Test example:
3+13,21i was: 31,32i×10¹ should be now: 3+1,32i×10¹
213^23+213^132i  was: 3,57×10⁵³2,22i×10³⁰⁷ should be now: 3,57×10⁵³+2,22i×10³⁰⁷