### PR TITLE
fix overflow handling in NOT

### DIFF
--- a/src/parserfunc.c
+++ b/src/parserfunc.c
@@ -866,7 +866,7 @@ pf_do_not(ParseNode* self)
     {
         set_error(self->state, PARSER_ERR_OVERFLOW, NULL);
         free(ans);
-        ans = NULL;
+        return NULL;
     }
     mp_not(val, self->state->options->wordlen, ans);
     free(val);


### PR DESCRIPTION
mp_not is called with NULL destination.
see #114