### PR TITLE
parserfunc: Return NULL on NOT operation overflow

### DIFF
--- a/src/mp-binary.c
+++ b/src/mp-binary.c
@@ -152,7 +152,7 @@ mp_not(const MPNumber *x, int wordlen, MPNumber *z)
 
     if (!mp_is_positive_integer(x))
     {
-        /* Translators: Error displayed when boolean XOR attempted on non-integer values */
+        /* Translators: Error displayed when boolean NOT attempted on non-integer values */
         mperr(_("Boolean NOT is only defined for positive integers"));
     }
 

--- a/src/parserfunc.c
+++ b/src/parserfunc.c
@@ -866,7 +866,8 @@ pf_do_not(ParseNode* self)
     {
         set_error(self->state, PARSER_ERR_OVERFLOW, NULL);
         free(ans);
-        ans = NULL;
+        free(val);
+        return NULL;
     }
     mp_not(val, self->state->options->wordlen, ans);
     free(val);


### PR DESCRIPTION
Fixes #114 
Closes #115 

To test, set the calc to Programming -> Hexadecimal and type `NOT ffffffffffffffffffffffffffffffff`.
Without this commit it segfaults. With this commit it should display "Overflow: Try a bigger word size"