### PR TITLE
sets the required version for gettext (0.19.8)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,6 +125,7 @@ variables:
   - CFLAGS="-Wall -Werror=format-security"
   - 'CHECKERS="
     -enable-checker deadcode.DeadStores
+    -enable-checker alpha.deadcode.UnreachableCode
     -enable-checker alpha.core.CastSize
     -enable-checker alpha.core.CastToStruct
     -enable-checker alpha.core.IdenticalExpr

--- a/configure.ac
+++ b/configure.ac
@@ -46,6 +46,7 @@ dnl ###########################################################################
 dnl Internationalization
 dnl ###########################################################################
 AM_GNU_GETTEXT_VERSION([0.19.8])
+AM_GNU_GETTEXT_REQUIRE_VERSION([0.19.8])
 AM_GNU_GETTEXT([external])
 AC_SUBST(GETTEXT_PACKAGE, mate-calc)
 


### PR DESCRIPTION
Fixes error in arch build:

`*** error: gettext infrastructure mismatch: using a Makefile.in.in from gettext version 0.19 but the autoconf macros are from gettext version 0.20`

The first commit is unrelated, is here just to see the error in travis of arch build.