### PR TITLE
The function 'mp_mask' is never used

### DIFF
--- a/src/mp-binary.c
+++ b/src/mp-binary.c
@@ -162,22 +162,6 @@ mp_not(const MPNumber *x, int wordlen, MPNumber *z)
 
 
 void
-mp_mask(const MPNumber *x, int wordlen, MPNumber *z)
-{
-    char *text;
-    size_t len, offset;
-
-    /* Convert to a hexadecimal string and use last characters */
-    text = to_hex_string(x);
-    len = strlen(text);
-    offset = wordlen / 4;
-    offset = len > offset ? len - offset: 0;
-    mp_set_from_string(text + offset, 16, z);
-    g_free(text);
-}
-
-
-void
 mp_shift(const MPNumber *x, int count, MPNumber *z)
 {
     int i;

--- a/src/mp.h
+++ b/src/mp.h
@@ -315,9 +315,6 @@ void   mp_xnor(const MPNumber *x, const MPNumber *y, int wordlen, MPNumber *z);
 /* Sets z = boolean NOT for each bit in x and z for word of length 'wordlen' */
 void   mp_not(const MPNumber *x, int wordlen, MPNumber *z);
 
-/* Sets z = x masked to 'wordlen' bits */
-void   mp_mask(const MPNumber *x, int wordlen, MPNumber *z);
-
 /* Sets z = x shifted by 'count' bits.  Positive shift increases the value, negative decreases */
 void   mp_shift(const MPNumber *x, int count, MPNumber *z);
 


### PR DESCRIPTION
 cppcheck --enable=unusedFunction .
 [src/mp-binary.c:165]: (style) The function 'mp_mask' is never used.