### PR TITLE
mate-calc.desktop.in: Add missing Keywords.

### DIFF
--- a/data/mate-calc.desktop.in
+++ b/data/mate-calc.desktop.in
@@ -7,6 +7,7 @@ Icon=accessories-calculator
 Terminal=false
 Type=Application
 StartupNotify=true
+Keywords=calculator;MATE;scientifc;arithmetic;financial;calculations;
 Categories=GTK;Utility;Calculator;
 X-MATE-DocPath=mate-calc/mate-calc.xml
 X-MATE-Bugzilla-Bugzilla=MATE


### PR DESCRIPTION
Taken from a downstream Debian patch.