### PR TITLE
History view

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -26,6 +26,10 @@ mate_calc_SOURCES = \
 	math-buttons.h \
 	math-converter.c \
 	math-converter.h \
+	math-history-view.c \
+	math-history-view.h \
+	math-history-entry-view.c \
+	math-history-entry-view.h \
 	math-display.c \
 	math-display.h \
 	math-equation.c \
@@ -194,6 +198,7 @@ EXTRA_DIST = \
 	mp-enums.h.template \
 	org.mate.calculator.gresource.xml \
 	preferences.ui
+
 
 DISTCLEANFILES = \
 	Makefile.in

--- a/src/math-display.c
+++ b/src/math-display.c
@@ -399,8 +399,7 @@ create_gui(MathDisplay *display)
     gtk_text_view_set_accepts_tab(GTK_TEXT_VIEW(display->priv->text_view), FALSE);
     gtk_text_view_set_pixels_above_lines(GTK_TEXT_VIEW(display->priv->text_view), 8);
     gtk_text_view_set_pixels_below_lines(GTK_TEXT_VIEW(display->priv->text_view), 2);
-    /* TEMP: Disabled for now as GTK+ doesn't properly render a right aligned right margin, see bug #482688 */
-    /*gtk_text_view_set_right_margin(GTK_TEXT_VIEW(display->priv->text_view), 6);*/
+    gtk_text_view_set_right_margin(GTK_TEXT_VIEW(display->priv->text_view), 6);
     gtk_text_view_set_justification(GTK_TEXT_VIEW(display->priv->text_view), GTK_JUSTIFY_RIGHT);
     context = gtk_widget_get_style_context (display->priv->text_view);
     state = gtk_widget_get_state_flags (GTK_WIDGET (display->priv->text_view));
@@ -412,19 +411,17 @@ create_gui(MathDisplay *display)
     atk_object_set_role(gtk_widget_get_accessible(display->priv->text_view), ATK_ROLE_EDITBAR);
   //FIXME:<property name="AtkObject::accessible-description" translatable="yes" comments="Accessible description for the area in which results are displayed">Result Region</property>
     g_signal_connect(display->priv->text_view, "key-press-event", G_CALLBACK(display_key_press_cb), display);
-    gtk_box_pack_start(GTK_BOX(main_box), display->priv->text_view, TRUE, TRUE, 0);
+    gtk_box_pack_start(GTK_BOX(main_box), display->priv->text_view, FALSE, TRUE, 0);
 
     info_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 6);
     gtk_box_pack_start(GTK_BOX(main_box), info_box, FALSE, TRUE, 0);
 
     info_view = gtk_text_view_new();
     gtk_text_view_set_wrap_mode(GTK_TEXT_VIEW(info_view), GTK_WRAP_WORD);
-    gtk_widget_set_can_focus(info_view, TRUE); // FIXME: This should be FALSE but it locks the cursor inside the main view for some reason
-    gtk_text_view_set_cursor_visible(GTK_TEXT_VIEW(info_view), FALSE); // FIXME: Just here so when incorrectly gets focus doesn't look editable
+    gtk_widget_set_can_focus(info_view, FALSE);
     gtk_text_view_set_editable(GTK_TEXT_VIEW(info_view), FALSE);
     gtk_text_view_set_justification(GTK_TEXT_VIEW(info_view), GTK_JUSTIFY_RIGHT);
-    /* TEMP: Disabled for now as GTK+ doesn't properly render a right aligned right margin, see bug #482688 */
-    /*gtk_text_view_set_right_margin(GTK_TEXT_VIEW(info_view), 6);*/
+    gtk_text_view_set_right_margin(GTK_TEXT_VIEW(info_view), 6);
     gtk_box_pack_start(GTK_BOX(info_box), info_view, TRUE, TRUE, 0);
     display->priv->info_buffer = gtk_text_view_get_buffer(GTK_TEXT_VIEW(info_view));
 

--- a/src/math-display.c
+++ b/src/math-display.c
@@ -366,7 +366,7 @@ update_history_cb (MathEquation *equation, char *answer, MPNumber *number, int n
 }
 
 void
-math_display_display_text (MathDisplay *display, char *prev_eq)
+math_display_display_text (MathDisplay *display, const char *prev_eq)
 {
    math_equation_set(display->priv->equation, prev_eq);
 }

--- a/src/math-display.h
+++ b/src/math-display.h
@@ -42,7 +42,7 @@ MathDisplay *math_display_new_with_equation(MathEquation *equation);
 MathEquation *math_display_get_equation(MathDisplay *display);
 
 void 
-math_display_display_text(MathDisplay *display, char *prev_eq);
+math_display_display_text(MathDisplay *display, const char *prev_eq);
 
 void
 math_display_insert_text(MathDisplay *display, char *answer);

--- a/src/math-display.h
+++ b/src/math-display.h
@@ -41,6 +41,12 @@ MathDisplay *math_display_new_with_equation(MathEquation *equation);
 
 MathEquation *math_display_get_equation(MathDisplay *display);
 
+void 
+math_display_display_text(MathDisplay *display, char *prev_eq);
+
+void
+math_display_insert_text(MathDisplay *display, char *answer);
+
 G_END_DECLS
 
 #endif /* MATH_DISPLAY_H */

--- a/src/math-equation.c
+++ b/src/math-equation.c
@@ -981,7 +981,7 @@ math_equation_set_number(MathEquation *equation, const MPNumber *x)
 
     /* Show the number in the user chosen format */
     text = mp_serializer_to_string(equation->priv->serializer, x);
-    g_signal_emit_by_name(equation, "history", state->expression, x, 10, 0);
+    g_signal_emit_by_name(equation, "history", state->expression, x, mp_serializer_get_base(equation->priv->serializer));
     gtk_text_buffer_set_text(GTK_TEXT_BUFFER(equation), text, -1);
     mp_set_from_mp(x, &equation->priv->state.ans);
 
@@ -1790,7 +1790,7 @@ math_equation_class_init(MathEquationClass *klass)
                                                         MP_TYPE_SERIALIZER,
                                                         G_PARAM_READABLE));
 
-    GType param_types[4] = {G_TYPE_STRING, G_TYPE_POINTER, G_TYPE_INT};
+    GType param_types[3] = {G_TYPE_STRING, G_TYPE_POINTER, G_TYPE_INT};
     g_signal_newv("history",
 			G_TYPE_FROM_CLASS(klass),
 			G_SIGNAL_RUN_LAST,

--- a/src/math-history-entry-view.c
+++ b/src/math-history-entry-view.c
@@ -1,11 +1,15 @@
 /*
- * Copyright (C) 2008-2011 Robert Ancell
+ * Copyright (C) 2020 MATE developers
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
  * Foundation, either version 2 of the License, or (at your option) any later
  * version. See http://www.gnu.org/copyleft/gpl.html the full text of the
  * license.
+ *
+ *
+ * Authors: Johannes Unruh <johannes.unruh@fau.de>
+ *
  */
 
 #include <string.h>
@@ -76,7 +80,7 @@ math_history_entry_view_new(char *equation, MPNumber *number, MathDisplay *displ
     view->priv->display = display;
     view->priv->answer = number;
     view->priv->prev_equation = equation;
-	MpSerializer *serializer = mp_serializer_new(MP_DISPLAY_FORMAT_AUTOMATIC, number_base, 9);
+    MpSerializer *serializer = mp_serializer_new(MP_DISPLAY_FORMAT_AUTOMATIC, number_base, 9);
     MpSerializer *ans_serializer = mp_serializer_new(MP_DISPLAY_FORMAT_AUTOMATIC, number_base, 4);
     view->priv->prev_answer = mp_serializer_to_string(serializer, view->priv->answer);
     char *answer_text = mp_serializer_to_string(ans_serializer, view->priv->answer);

--- a/src/math-history-entry-view.c
+++ b/src/math-history-entry-view.c
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2008-2011 Robert Ancell
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version. See http://www.gnu.org/copyleft/gpl.html the full text of the
+ * license.
+ */
+
+#include <string.h>
+#include <glib/gi18n.h>
+#include <gdk/gdkkeysyms.h>
+
+#include "math-history-entry-view.h"
+
+struct MathHistoryEntryViewPrivate
+{
+    MPNumber *answer; /* Stores answer in Number object */
+    char *prev_equation; /* Stores equation to be entered in history-view */
+    char *prev_answer; /* Stores answer to be entered in history-view */
+    GtkWidget *equation_label;
+    GtkWidget *answer_label;
+    GtkWidget *eq_eventbox;
+    GtkWidget *ans_eventbox;
+    MathDisplay *display;
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE (MathHistoryEntryView, math_history_entry_view, GTK_TYPE_LIST_BOX_ROW);
+
+gboolean
+onclick_answer (GtkWidget *widget, GdkEventButton *eventbutton, gpointer data)
+{   /* Callback function for button-press-event on ans_eventbox */
+    GtkEventBox *event = (GtkEventBox*) widget;
+    MathHistoryEntryView *view = MATH_HISTORY_ENTRY_VIEW(data);
+    if (event != NULL)
+    {
+        if (GTK_IS_BIN(event))
+        {
+            GtkWidget *ans_label = gtk_bin_get_child(GTK_BIN(event));
+            char *prev_ans = gtk_widget_get_tooltip_text(ans_label);
+            if (prev_ans  != NULL)
+            {
+                math_display_insert_text(view->priv->display, prev_ans); /* Replaces current equation by selected equation from history-view */
+            }
+        }
+    }
+    return TRUE;
+}
+
+gboolean
+onclick_equation (GtkWidget *widget, GdkEventButton *eventbutton, gpointer data)
+{   /* Callback function for button-press-event on eq_eventbox */
+    GtkEventBox *event = (GtkEventBox*) widget;
+    MathHistoryEntryView *view = MATH_HISTORY_ENTRY_VIEW(data);
+    if (event != NULL)
+    {
+        if (GTK_IS_BIN(event))
+        {
+            GtkLabel *equation_label = (GtkLabel*) gtk_bin_get_child(GTK_BIN(event));
+            char *prev_equation = gtk_label_get_text(equation_label);
+            if (prev_equation  != NULL)
+            {
+                math_display_display_text (view->priv->display, prev_equation); /* Appends selected answer from history-view to current equation in editbar */
+            }
+        }
+    }
+    return TRUE;
+}
+
+MathHistoryEntryView *
+math_history_entry_view_new(char *equation, MPNumber *number, MathDisplay *display, int number_base)
+{   /* Creates a new history-view entry */
+    MathHistoryEntryView *view = g_object_new(math_history_entry_view_get_type(), NULL);
+
+    view->priv->display = display;
+    view->priv->answer = number;
+    view->priv->prev_equation = equation;
+	MpSerializer *serializer = mp_serializer_new(MP_DISPLAY_FORMAT_AUTOMATIC, number_base, 9);
+    MpSerializer *ans_serializer = mp_serializer_new(MP_DISPLAY_FORMAT_AUTOMATIC, number_base, 4);
+    view->priv->prev_answer = mp_serializer_to_string(serializer, view->priv->answer);
+    char *answer_text = mp_serializer_to_string(ans_serializer, view->priv->answer);
+    GtkWidget *grid = gtk_grid_new();
+    gtk_grid_insert_column(GTK_GRID(grid), 0);
+    gtk_grid_insert_column(GTK_GRID(grid), 1);
+    gtk_grid_insert_column(GTK_GRID(grid), 2);
+    gtk_grid_insert_column(GTK_GRID(grid), 3);
+    gtk_grid_insert_row(GTK_GRID(grid), 0);
+    gtk_grid_set_column_homogeneous(GTK_GRID(grid), TRUE);
+    gtk_container_add(GTK_CONTAINER(view), grid);
+    view->priv->equation_label = gtk_label_new("");
+    view->priv->answer_label = gtk_label_new("");
+    view->priv->eq_eventbox = gtk_event_box_new();
+    view->priv->ans_eventbox = gtk_event_box_new();
+    gtk_container_add(GTK_CONTAINER(view->priv->eq_eventbox), view->priv->equation_label);
+    gtk_container_add(GTK_CONTAINER(view->priv->ans_eventbox), view->priv->answer_label);
+    gtk_widget_set_events(view->priv->eq_eventbox, GDK_BUTTON_PRESS_MASK);
+    gtk_widget_set_events(view->priv->ans_eventbox, GDK_BUTTON_PRESS_MASK);
+    g_signal_connect(view->priv->eq_eventbox, "button_press_event", G_CALLBACK(onclick_equation), view); /* Calls onclick_equation on clicking on equation_label */
+    g_signal_connect(view->priv->ans_eventbox, "button_press_event", G_CALLBACK(onclick_answer), view); /* Calls onclick_answer on clicking on answer_label */
+    gtk_widget_set_size_request(view->priv->equation_label, 10, 10);
+    gtk_widget_set_size_request(view->priv->answer_label, 10, 10);
+    gtk_label_set_selectable(GTK_LABEL(view->priv->equation_label), TRUE);
+    gtk_label_set_selectable(GTK_LABEL(view->priv->answer_label), TRUE);
+    gtk_event_box_set_above_child (GTK_EVENT_BOX(view->priv->eq_eventbox), TRUE);
+    gtk_event_box_set_above_child (GTK_EVENT_BOX(view->priv->ans_eventbox), TRUE);
+    gtk_widget_set_tooltip_text (view->priv->equation_label, view->priv->prev_equation); /* Sets tooltip for equation_label */
+    gtk_widget_set_tooltip_text(view->priv->answer_label, view->priv->prev_answer); /* Sets tooltip for answer_label */
+    gtk_label_set_ellipsize(GTK_LABEL(view->priv->equation_label), PANGO_ELLIPSIZE_END); /* Ellipsizes the equation when its size is greater than the size of the equation_label */
+    gtk_label_set_ellipsize(GTK_LABEL(view->priv->answer_label), PANGO_ELLIPSIZE_END); /* Elipsizes the answer when its size is greater the than size of answer_label */
+    gtk_label_set_text(GTK_LABEL(view->priv->equation_label), view->priv->prev_equation);
+    char* final_answer = g_strconcat("= ", answer_text, NULL);
+    gtk_label_set_text(GTK_LABEL(view->priv->answer_label), final_answer);
+    gtk_grid_attach(GTK_GRID(grid), view->priv->eq_eventbox, 0, 0, 3, 1);
+    gtk_grid_attach(GTK_GRID(grid), view->priv->ans_eventbox, 3, 0, 1, 1);
+    gtk_label_set_xalign(GTK_LABEL(view->priv->equation_label), 0); /* Aligns equation_label to the left */
+    gtk_label_set_xalign(GTK_LABEL(view->priv->answer_label), 1); /* Aligns answer_label to the right */
+    PangoAttrList *list = pango_attr_list_new ();
+    PangoFontDescription *font = pango_font_description_new ();
+    pango_font_description_set_weight (font, PANGO_WEIGHT_BOLD);
+    PangoAttribute *weight = pango_attr_weight_new (PANGO_WEIGHT_BOLD);
+    pango_attr_list_insert(list, weight);
+    gtk_label_set_attributes(GTK_LABEL(view->priv->answer_label), list); /* Sets font weight of the text on answer_label to BOLD */
+
+    gtk_widget_show_all(grid);
+    g_free(final_answer);
+
+    return view;
+}
+
+static void
+math_history_entry_view_class_init(MathHistoryEntryViewClass *klass)
+{
+}
+
+static void
+math_history_entry_view_init(MathHistoryEntryView *view)
+{
+    view->priv = math_history_entry_view_get_instance_private(view);
+}

--- a/src/math-history-entry-view.c
+++ b/src/math-history-entry-view.c
@@ -28,8 +28,8 @@ struct MathHistoryEntryViewPrivate
 
 G_DEFINE_TYPE_WITH_PRIVATE (MathHistoryEntryView, math_history_entry_view, GTK_TYPE_LIST_BOX_ROW);
 
-gboolean
-onclick_answer (GtkWidget *widget, GdkEventButton *eventbutton, gpointer data)
+static gboolean
+answer_clicked_cb (GtkWidget *widget, GdkEventButton *eventbutton, gpointer data)
 {   /* Callback function for button-press-event on ans_eventbox */
     GtkEventBox *event = (GtkEventBox*) widget;
     MathHistoryEntryView *view = MATH_HISTORY_ENTRY_VIEW(data);
@@ -48,8 +48,8 @@ onclick_answer (GtkWidget *widget, GdkEventButton *eventbutton, gpointer data)
     return TRUE;
 }
 
-gboolean
-onclick_equation (GtkWidget *widget, GdkEventButton *eventbutton, gpointer data)
+static gboolean
+equation_clicked_cb (GtkWidget *widget, GdkEventButton *eventbutton, gpointer data)
 {   /* Callback function for button-press-event on eq_eventbox */
     GtkEventBox *event = (GtkEventBox*) widget;
     MathHistoryEntryView *view = MATH_HISTORY_ENTRY_VIEW(data);
@@ -58,7 +58,7 @@ onclick_equation (GtkWidget *widget, GdkEventButton *eventbutton, gpointer data)
         if (GTK_IS_BIN(event))
         {
             GtkLabel *equation_label = (GtkLabel*) gtk_bin_get_child(GTK_BIN(event));
-            char *prev_equation = gtk_label_get_text(equation_label);
+            const char *prev_equation = gtk_label_get_text(equation_label);
             if (prev_equation  != NULL)
             {
                 math_display_display_text (view->priv->display, prev_equation); /* Appends selected answer from history-view to current equation in editbar */
@@ -96,8 +96,8 @@ math_history_entry_view_new(char *equation, MPNumber *number, MathDisplay *displ
     gtk_container_add(GTK_CONTAINER(view->priv->ans_eventbox), view->priv->answer_label);
     gtk_widget_set_events(view->priv->eq_eventbox, GDK_BUTTON_PRESS_MASK);
     gtk_widget_set_events(view->priv->ans_eventbox, GDK_BUTTON_PRESS_MASK);
-    g_signal_connect(view->priv->eq_eventbox, "button_press_event", G_CALLBACK(onclick_equation), view); /* Calls onclick_equation on clicking on equation_label */
-    g_signal_connect(view->priv->ans_eventbox, "button_press_event", G_CALLBACK(onclick_answer), view); /* Calls onclick_answer on clicking on answer_label */
+    g_signal_connect(view->priv->eq_eventbox, "button_press_event", G_CALLBACK(equation_clicked_cb), view); /* Calls onclick_equation on clicking on equation_label */
+    g_signal_connect(view->priv->ans_eventbox, "button_press_event", G_CALLBACK(answer_clicked_cb), view); /* Calls onclick_answer on clicking on answer_label */
     gtk_widget_set_size_request(view->priv->equation_label, 10, 10);
     gtk_widget_set_size_request(view->priv->answer_label, 10, 10);
     gtk_label_set_selectable(GTK_LABEL(view->priv->equation_label), TRUE);

--- a/src/math-history-entry-view.h
+++ b/src/math-history-entry-view.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2008-2011 Robert Ancell
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version. See http://www.gnu.org/copyleft/gpl.html the full text of the
+ * license.
+ */
+
+#ifndef MATH_HISTORY_ENTRY_VIEW_H
+#define MATH_HISTORY_ENTRY_VIEW_H
+
+#include <glib-object.h>
+#include <gtk/gtk.h>
+
+#include "math-display.h"
+#include "math-history-view.h"
+
+G_BEGIN_DECLS
+
+#define MATH_HISTORY_ENTRY_VIEW(obj) (G_TYPE_CHECK_INSTANCE_CAST ((obj), math_history_entry_view_get_type(), MathHistoryEntryView))
+
+typedef struct MathHistoryEntryViewPrivate MathHistoryEntryViewPrivate;
+
+typedef struct
+{
+    GtkListBoxRow parent_instance;
+    MathHistoryEntryViewPrivate *priv;
+} MathHistoryEntryView;
+
+typedef struct
+{
+    GtkListBoxRowClass parent_class;
+} MathHistoryEntryViewClass;
+
+GType math_history_entry_view_get_type(void);
+
+MathHistoryEntryView *
+math_history_entry_view_new(char *equation, MPNumber *number, MathDisplay *display, int number_base);
+
+gboolean
+onclick_answer(GtkWidget *widget, GdkEventButton *eventbutton, gpointer data);
+
+gboolean
+onclick_equation(GtkWidget *widget, GdkEventButton *eventbutton, gpointer data);
+
+G_END_DECLS
+
+#endif /* MATH_HISTORY_ENTRY_VIEW_H */

--- a/src/math-history-entry-view.h
+++ b/src/math-history-entry-view.h
@@ -1,11 +1,15 @@
 /*
- * Copyright (C) 2008-2011 Robert Ancell
+ * Copyright (C) 2020 MATE developers
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
  * Foundation, either version 2 of the License, or (at your option) any later
  * version. See http://www.gnu.org/copyleft/gpl.html the full text of the
  * license.
+ *
+ *
+ * Authors: Johannes Unruh <johannes.unruh@fau.de>
+ *
  */
 
 #ifndef MATH_HISTORY_ENTRY_VIEW_H

--- a/src/math-history-entry-view.h
+++ b/src/math-history-entry-view.h
@@ -39,12 +39,6 @@ GType math_history_entry_view_get_type(void);
 MathHistoryEntryView *
 math_history_entry_view_new(char *equation, MPNumber *number, MathDisplay *display, int number_base);
 
-gboolean
-onclick_answer(GtkWidget *widget, GdkEventButton *eventbutton, gpointer data);
-
-gboolean
-onclick_equation(GtkWidget *widget, GdkEventButton *eventbutton, gpointer data);
-
 G_END_DECLS
 
 #endif /* MATH_HISTORY_ENTRY_VIEW_H */

--- a/src/math-history-view.c
+++ b/src/math-history-view.c
@@ -1,11 +1,15 @@
 /*
- * Copyright (C) 2008-2011 Robert Ancell
+ * Copyright (C) 2020 MATE developers
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
  * Foundation, either version 2 of the License, or (at your option) any later
  * version. See http://www.gnu.org/copyleft/gpl.html the full text of the
  * license.
+ *
+ *
+ * Authors: Johannes Unruh <johannes.unruh@fau.de>
+ *
  */
 
 #include <string.h>

--- a/src/math-history-view.c
+++ b/src/math-history-view.c
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2008-2011 Robert Ancell
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version. See http://www.gnu.org/copyleft/gpl.html the full text of the
+ * license.
+ */
+
+#include <string.h>
+#include <glib/gi18n.h>
+#include <gdk/gdkkeysyms.h>
+
+#include "math-history-view.h"
+
+struct MathHistoryViewPrivate
+{
+    int no_ofitems; /* No of entries in history-view listbox */
+
+    GtkWidget *listbox;
+    GtkWidget *scroll_window;
+    GtkWidget *main_box;
+    MathDisplay *display;
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE(MathHistoryView, math_history_view, GTK_TYPE_BOX);
+
+static void
+scroll_changed_cb(GtkAdjustment *adjustment, MathHistoryView *view)
+{
+    gtk_adjustment_set_value(adjustment, gtk_adjustment_get_upper(adjustment));
+}
+
+static gboolean
+check_history(MathHistoryView *view, char *equation, char *answer)
+{ /* Checks if the last inserted calculation is the same as the current calculation to be inserted in history-view */
+    if (view->priv->no_ofitems == 0)
+    {
+        return FALSE; /* returns false for the first entry */
+    }
+
+    char *current_equation = equation;
+    char *ans = answer;
+    GtkListBoxRow *row = gtk_list_box_get_row_at_index(GTK_LIST_BOX(view->priv->listbox), view->priv->no_ofitems - 1);
+    GtkGrid *grid = GTK_GRID(gtk_bin_get_child(GTK_BIN(row)));
+    if (grid != NULL)
+    {
+        GtkEventBox *ans_eventbox = GTK_EVENT_BOX(g_list_nth_data(gtk_container_get_children(GTK_CONTAINER(grid)), 0));
+        char *prev_ans = gtk_widget_get_tooltip_text(GTK_WIDGET(gtk_bin_get_child(GTK_BIN(ans_eventbox)))); /* retrieves previous equation */
+        GtkEventBox *eq_eventbox = GTK_EVENT_BOX(g_list_nth_data(gtk_container_get_children(GTK_CONTAINER(grid)), 1));
+        char *prev_equation = gtk_widget_get_tooltip_text(GTK_WIDGET(gtk_bin_get_child(GTK_BIN(eq_eventbox)))); /* retrieves previous answer */
+        if ((view->priv->no_ofitems >= 1) && (strcmp(prev_ans, ans)==0) && (strcmp(current_equation, prev_equation)==0))
+            return TRUE; /* returns true if last entered equation and answer is the same as the current equation and answer */
+    }
+    return FALSE;
+}
+
+void
+math_history_insert_entry (MathHistoryView *view, char *equation, MPNumber *answer, int number_base)
+{   /* Inserts a new entry into the history-view listbox */
+    char *prev_eq = equation;
+    MpSerializer *serializer = mp_serializer_new(MP_DISPLAY_FORMAT_AUTOMATIC, number_base, 9);
+    char *ans = mp_serializer_to_string(serializer, answer);
+    gboolean check = check_history (view, prev_eq, ans);
+    if (!check)
+    {
+        MathHistoryEntryView *entry = math_history_entry_view_new (prev_eq, answer, view->priv->display, number_base);
+        if (entry != NULL)	
+        {
+            gtk_container_add(GTK_CONTAINER(view->priv->listbox), GTK_WIDGET(entry));
+            gtk_widget_show_all(GTK_WIDGET(entry));	
+            view->priv->no_ofitems += 1;
+        }	
+    }
+}
+
+MathHistoryView *
+math_history_view_new(MathDisplay *display, GtkWidget *box)
+{
+    MathHistoryView *view = g_object_new(math_history_view_get_type(), NULL);
+    view->priv->display = display;
+    view->priv->main_box = box;
+    view->priv->listbox = gtk_list_box_new();    
+    gtk_list_box_set_selection_mode(GTK_LIST_BOX(view->priv->listbox), GTK_SELECTION_NONE);
+    gtk_container_set_border_width(GTK_CONTAINER(view->priv->listbox), 5);
+    view->priv->scroll_window = gtk_scrolled_window_new (NULL, NULL);
+    gtk_scrolled_window_set_shadow_type (GTK_SCROLLED_WINDOW(view->priv->scroll_window), GTK_SHADOW_ETCHED_OUT);
+    gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(view->priv->scroll_window), GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
+    gtk_scrolled_window_set_placement (GTK_SCROLLED_WINDOW(view->priv->scroll_window), GTK_CORNER_TOP_LEFT);
+    gtk_container_add(GTK_CONTAINER(view->priv->scroll_window), view->priv->listbox);
+    gtk_widget_set_size_request(view->priv->scroll_window, 100, 100);
+    gtk_box_pack_start(GTK_BOX(view->priv->main_box), view->priv->scroll_window, TRUE, TRUE, 0);
+    g_signal_connect(gtk_scrolled_window_get_vadjustment(GTK_SCROLLED_WINDOW(view->priv->scroll_window)), "changed", G_CALLBACK(scroll_changed_cb), view);
+    gtk_widget_show_all(view->priv->main_box);
+    return view;
+}
+
+static void
+math_history_view_class_init(MathHistoryViewClass *klass)
+{
+}
+
+static void
+math_history_view_init(MathHistoryView *view)
+{
+    view->priv = math_history_view_get_instance_private(view);
+    view->priv->no_ofitems = 0;
+}

--- a/src/math-history-view.h
+++ b/src/math-history-view.h
@@ -1,11 +1,15 @@
 /*
- * Copyright (C) 2008-2011 Robert Ancell
+ * Copyright (C) 2020 MATE developers
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
  * Foundation, either version 2 of the License, or (at your option) any later
  * version. See http://www.gnu.org/copyleft/gpl.html the full text of the
  * license.
+ *
+ *
+ * Authors: Johannes Unruh <johannes.unruh@fau.de>
+ *
  */
 
 #ifndef MATH_HISTORY_VIEW_H

--- a/src/math-history-view.h
+++ b/src/math-history-view.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2008-2011 Robert Ancell
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version. See http://www.gnu.org/copyleft/gpl.html the full text of the
+ * license.
+ */
+
+#ifndef MATH_HISTORY_VIEW_H
+#define MATH_HISTORY_VIEW_H
+
+#include <glib-object.h>
+#include <gtk/gtk.h>
+
+#include "math-history-entry-view.h"
+#include "math-display.h"
+#include "math-equation.h"
+
+G_BEGIN_DECLS
+
+#define MATH_HISTORY_VIEW(obj) (G_TYPE_CHECK_INSTANCE_CAST ((obj), math_history_view_get_type(), MathHistoryView))
+
+typedef struct MathHistoryViewPrivate MathHistoryViewPrivate;
+
+typedef struct
+{
+    GtkBox parent_instance;
+    MathHistoryViewPrivate *priv;
+} MathHistoryView;
+
+typedef struct
+{
+    GtkBoxClass parent_class;
+} MathHistoryViewClass;
+
+GType math_history_view_get_type(void);
+
+MathHistoryView *
+math_history_view_new(MathDisplay *display, GtkWidget *box);
+
+void
+math_history_insert_entry(MathHistoryView *view, char *equation, MPNumber *answer, int number_base);
+
+G_END_DECLS
+
+#endif /* MATH_HISTORY_VIEW_H */

--- a/src/math-window.c
+++ b/src/math-window.c
@@ -459,7 +459,7 @@ create_gui(MathWindow *window)
     gtk_widget_show(main_vbox);
 
     window->priv->menu_bar = gtk_menu_bar_new();
-    gtk_box_pack_start(GTK_BOX(main_vbox), window->priv->menu_bar, TRUE, TRUE, 0);
+    gtk_box_pack_start(GTK_BOX(main_vbox), window->priv->menu_bar, FALSE, TRUE, 0);
     gtk_widget_show(window->priv->menu_bar);
 
     create_menu(window);
@@ -469,6 +469,7 @@ create_gui(MathWindow *window)
     gtk_box_pack_start(GTK_BOX(main_vbox), vbox, TRUE, TRUE, 0);
     gtk_widget_show(vbox);
 
+    //TODO move display out of scrolled window to make history view independent from it
     scrolled_window = gtk_scrolled_window_new(NULL, NULL);
     gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scrolled_window), GTK_POLICY_AUTOMATIC, GTK_POLICY_NEVER);
     gtk_scrolled_window_set_shadow_type(GTK_SCROLLED_WINDOW(scrolled_window), GTK_SHADOW_IN);
@@ -485,7 +486,7 @@ create_gui(MathWindow *window)
     window->priv->buttons = math_buttons_new(window->priv->equation);
     g_signal_connect(window->priv->buttons, "notify::mode", G_CALLBACK(button_mode_changed_cb), window);
     button_mode_changed_cb(window->priv->buttons, NULL, window);
-    gtk_box_pack_start(GTK_BOX(vbox), GTK_WIDGET(window->priv->buttons), TRUE, TRUE, 0);
+    gtk_box_pack_start(GTK_BOX(vbox), GTK_WIDGET(window->priv->buttons), FALSE, TRUE, 0);
     gtk_widget_show(GTK_WIDGET(window->priv->buttons));
 }
 
@@ -568,7 +569,7 @@ math_window_init(MathWindow *window)
                          _("Calculator"));
     gtk_window_set_icon_name(GTK_WINDOW(window), "accessories-calculator");
     gtk_window_set_role(GTK_WINDOW(window), "mate-calc");
-    gtk_window_set_resizable(GTK_WINDOW(window), FALSE);
+    gtk_window_set_resizable(GTK_WINDOW(window), TRUE);
     g_signal_connect_after(G_OBJECT(window), "key-press-event", G_CALLBACK(key_press_cb), NULL);
     g_signal_connect(G_OBJECT(window), "delete-event", G_CALLBACK(delete_cb), NULL);
 }


### PR DESCRIPTION
Hi there!
I made a history view for mate-calc based on https://gitlab.gnome.org/GNOME/gnome-calculator/commit/e5c307320db02e0f22b6e61e3b40109a1668a506

![Peek_2020-01-23_20-10](https://user-images.githubusercontent.com/39454100/73016822-e929e780-3e1e-11ea-9b35-5b7799adaaa6.gif)

The second commit makes mate-calc resizeable and removes fixmes  due to an (probably) old gtk bug in mate-display.c, so that there is a little right margin next to the cursor.
As I am fairly new to GObject programming in C any feedback would be appreciated.
Furthermore, I would like to be able to contribute more to mate-desktop development and documentation, do you guys have a mailing list, or forum or something?
Fixes #32 