### PR TITLE
Remove warnings: function declaration isn’t a prototype

### DIFF
--- a/src/currency-manager.c
+++ b/src/currency-manager.c
@@ -167,7 +167,7 @@ currency_manager_get_currency(CurrencyManager *manager, const gchar *name)
 
 
 static char *
-get_imf_rate_filepath()
+get_imf_rate_filepath(void)
 {
     return g_build_filename(g_get_user_cache_dir (),
                             "mate-calc",
@@ -177,7 +177,7 @@ get_imf_rate_filepath()
 
 
 static char *
-get_ecb_rate_filepath()
+get_ecb_rate_filepath(void)
 {
     return g_build_filename(g_get_user_cache_dir (),
                             "mate-calc",

--- a/src/test-mp-equation.c
+++ b/src/test-mp-equation.c
@@ -118,7 +118,7 @@ do_convert(const MPNumber *x, const char *x_units, const char *z_units, MPNumber
 
 
 static void
-test_conversions()
+test_conversions(void)
 {
     memset(&options, 0, sizeof(options));
     options.base = 10;
@@ -186,7 +186,7 @@ set_variable(const char *name, const MPNumber *x, void *data)
 }
 
 static void
-test_equations()
+test_equations(void)
 {
     memset(&options, 0, sizeof(options));
     options.wordlen = 32;

--- a/src/test-mp.c
+++ b/src/test-mp.c
@@ -97,7 +97,7 @@ test_integer(int number)
 
 
 static void
-test_numbers()
+test_numbers(void)
 {
     printf("base=%d\n", MP_BASE);
     test_integer(0);
@@ -141,7 +141,7 @@ try(const char *string, bool result, bool expected)
 
 
 static void
-test_mp()
+test_mp(void)
 {
     MPNumber zero, one, minus_one;
 


### PR DESCRIPTION
```
currency-manager.c:170:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
  170 | get_imf_rate_filepath()
      | ^~~~~~~~~~~~~~~~~~~~~

currency-manager.c:180:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
  180 | get_ecb_rate_filepath()
      | ^~~~~~~~~~~~~~~~~~~~~

test-mp.c:100:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
  100 | test_numbers()
      | ^~~~~~~~~~~~

test-mp.c:144:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
  144 | test_mp()
      | ^~~~~~~

test-mp-equation.c:121:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
  121 | test_conversions()
      | ^~~~~~~~~~~~~~~~

test-mp-equation.c:189:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
  189 | test_equations()
      | ^~~~~~~~~~~~~~
```