### PR TITLE
Remove '<data_type> abs (<data_type>)' warnings

### DIFF
--- a/src/mp-convert.c
+++ b/src/mp-convert.c
@@ -484,7 +484,7 @@ mp_cast_to_double(const MPNumber *x)
     /* LHS SHOULD BE .LE. 0.5 BUT ALLOW FOR SOME ERROR IN DLOG */
     if (ret_val <= 0. ||
         ((d__1 = (double) ((float) x->exponent) - (log(ret_val) / log((double)
-                ((float) MP_BASE)) + .5), abs(d__1)) > .6)) {
+                ((float) MP_BASE)) + .5), fabs(d__1)) > .6)) {
         /*  FOLLOWING MESSAGE INDICATES THAT X IS TOO LARGE OR SMALL -
          *  TRY USING MPCMDE INSTEAD.
          */

--- a/src/mp.c
+++ b/src/mp.c
@@ -1098,8 +1098,8 @@ mp_gcd(int64_t *k, int64_t *l)
 {
     int64_t i, j;
 
-    i = abs(*k);
-    j = abs(*l);
+    i = labs(*k);
+    j = labs(*l);
     if (j == 0) {
         /* IF J = 0 RETURN (1, 0) UNLESS I = 0, THEN (0, 0) */
         *k = 1;


### PR DESCRIPTION
```
mp.c: In function ‘mp_gcd’:
mp.c:1101:9: warning: absolute value function ‘abs’ given an argument of type ‘int64_t’ {aka ‘long int’} but has parameter of type ‘int’ which may cause truncation of value [-Wabsolute-value]
 1101 |     i = abs(*k);

      |         ^~~
mp.c:1102:9: warning: absolute value function ‘abs’ given an argument of type ‘int64_t’ {aka ‘long int’} but has parameter of type ‘int’ which may cause truncation of value [-Wabsolute-value]
 1102 |     j = abs(*l);
      |         ^~~

mp-convert.c: In function ‘mp_cast_to_double’:
mp-convert.c:487:43: warning: using integer absolute value function ‘abs’ when argument is of floating-point type ‘double’ [-Wabsolute-value]
  487 |                 ((float) MP_BASE)) + .5), abs(d__1)) > .6)) {
      |                                           ^~~
```