### PR TITLE
history-view

### DIFF
--- a/data/org.mate.calc.gschema.xml
+++ b/data/org.mate.calc.gschema.xml
@@ -47,6 +47,11 @@
       <summary>Show Trailing Zeroes</summary>
       <description>Indicates whether any trailing zeroes after the  numeric point should be shown in the display value.</description>
     </key>
+    <key type="b" name="show-history">
+      <default>false</default>
+      <summary>Show History</summary>
+      <description>Shows all recent calculations</description>
+    </key>
     <key name="number-format" enum="org.mate.calc.NumberFormat">
       <default>'automatic'</default>
       <summary>Number format</summary>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -26,6 +26,10 @@ mate_calc_SOURCES = \
 	math-buttons.h \
 	math-converter.c \
 	math-converter.h \
+	math-history.c \
+	math-history.h \
+	math-history-entry.c \
+	math-history-entry.h \
 	math-display.c \
 	math-display.h \
 	math-equation.c \
@@ -194,6 +198,7 @@ EXTRA_DIST = \
 	mp-enums.c.template \
 	mp-enums.h.template \
 	org.mate.calculator.gresource.xml \
+	history-entry.ui \
 	preferences.ui
 
 DISTCLEANFILES = \

--- a/src/history-entry.ui
+++ b/src/history-entry.ui
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
+<interface>
+  <requires lib="gtk+" version="3.22"/>
+  <object class="GtkGrid" id="grid">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="margin_left">12</property>
+    <property name="margin_right">16</property>
+    <property name="margin_start">12</property>
+    <property name="margin_end">16</property>
+    <property name="column_homogeneous">True</property>
+    <child>
+      <object class="GtkEventBox" id="equation_eventbox">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <signal name="button-press-event" handler="equation_clicked_cb" swapped="no"/>
+        <child>
+          <object class="GtkLabel" id="equation_label">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="ellipsize">end</property>
+            <property name="max_width_chars">1</property>
+            <property name="xalign">0</property>
+            <property name="yalign">0.5</property>
+            <attributes>
+              <attribute name="size" value="14000"/>
+            </attributes>
+          </object>
+        </child>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">0</property>
+        <property name="width">4</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel" id="equation_symbol">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="label">=</property>
+        <property name="max_width_chars">1</property>
+        <property name="xalign">0.5</property>
+        <property name="yalign">0.5</property>
+        <attributes>
+          <attribute name="weight" value="light"/>
+          <attribute name="size" value="12000"/>
+        </attributes>
+      </object>
+      <packing>
+        <property name="left_attach">4</property>
+        <property name="top_attach">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkEventBox" id="answer_eventbox">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <signal name="button-press-event" handler="answer_clicked_cb" swapped="no"/>
+        <child>
+          <object class="GtkLabel" id="answer_label">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="ellipsize">end</property>
+            <property name="max_width_chars">12</property>
+            <property name="xalign">1</property>
+            <property name="yalign">0.5</property>
+            <attributes>
+              <attribute name="weight" value="bold"/>
+              <attribute name="size" value="14000"/>
+            </attributes>
+          </object>
+        </child>
+      </object>
+      <packing>
+        <property name="left_attach">5</property>
+        <property name="top_attach">0</property>
+        <property name="width">2</property>
+      </packing>
+    </child>
+  </object>
+</interface>

--- a/src/mate-calc.c
+++ b/src/mate-calc.c
@@ -190,7 +190,7 @@ int main(int argc, char **argv)
     MathEquation *equation;
     MathButtons *buttons;
     int accuracy = 9, word_size = 64, base = 10;
-    gboolean show_tsep = FALSE, show_zeroes = FALSE;
+    gboolean show_tsep = FALSE, show_zeroes = FALSE, show_hist = FALSE;
     MpDisplayFormat number_format;
     MPAngleUnit angle_units;
     ButtonMode button_mode;
@@ -213,6 +213,7 @@ int main(int argc, char **argv)
     base = g_settings_get_int(g_settings_var, "base");
     show_tsep = g_settings_get_boolean(g_settings_var, "show-thousands");
     show_zeroes = g_settings_get_boolean(g_settings_var, "show-zeroes");
+    show_hist = g_settings_get_boolean(g_settings_var, "show-history");
     number_format = g_settings_get_enum(g_settings_var, "number-format");
     angle_units = g_settings_get_enum(g_settings_var, "angle-units");
     button_mode = g_settings_get_enum(g_settings_var, "button-mode");
@@ -244,6 +245,7 @@ int main(int argc, char **argv)
     window = math_window_new(equation);
     buttons = math_window_get_buttons(window);
     g_signal_connect(G_OBJECT(window), "quit", G_CALLBACK(quit_cb), NULL);
+    math_window_set_show_history(window, show_hist);
     math_buttons_set_programming_base(buttons, base);
     math_buttons_set_mode(buttons, button_mode); // FIXME: We load the basic buttons even if we immediately switch to the next type
 

--- a/src/math-equation.c
+++ b/src/math-equation.c
@@ -975,9 +975,14 @@ math_equation_set_number(MathEquation *equation, const MPNumber *x)
 {
     char *text;
     GtkTextIter start, end;
+    MathEquationState *state;
 
     g_return_if_fail(equation != NULL);
     g_return_if_fail(x != NULL);
+
+    /* Notify history */
+    state = get_current_state(equation);
+    g_signal_emit_by_name(equation, "history", state->expression, x, mp_serializer_get_base(equation->priv->serializer));
 
     /* Show the number in the user chosen format */
     text = mp_serializer_to_string(equation->priv->serializer, x);
@@ -1788,8 +1793,19 @@ math_equation_class_init(MathEquationClass *klass)
                                                         "Serializer",
                                                         MP_TYPE_SERIALIZER,
                                                         G_PARAM_READABLE));
-}
 
+    GType param_types[3] = {G_TYPE_STRING, G_TYPE_POINTER, G_TYPE_INT};
+    g_signal_newv("history",
+                  G_TYPE_FROM_CLASS(klass),
+                  G_SIGNAL_RUN_LAST,
+                  0,
+                  NULL,
+                  NULL,
+                  NULL,
+                  G_TYPE_NONE,
+                  3,
+                  param_types);
+}
 
 static void
 pre_insert_text_cb(MathEquation  *equation,

--- a/src/math-history-entry.c
+++ b/src/math-history-entry.c
@@ -98,8 +98,8 @@ math_history_entry_insert_entry(MathHistoryEntry *history_entry, char *equation,
     builder = gtk_builder_new();
     if(gtk_builder_add_from_resource (builder, UI_HISTORY_ENTRY_RESOURCE_PATH, &error) == 0)
     {
-        g_print("gtk_builder_add_from_resource FAILED\n");
-        g_print("%s\n",error->message);
+        g_warning("Error loading history-entry UI: %s", error->message);
+        g_clear_error(&error);
         return;
     }
     grid = GET_WIDGET(builder, "grid");
@@ -113,6 +113,7 @@ math_history_entry_insert_entry(MathHistoryEntry *history_entry, char *equation,
     gtk_label_set_text(GTK_LABEL(history_entry->priv->equation_label), history_entry->priv->equation_string);
     gtk_label_set_text(GTK_LABEL(history_entry->priv->answer_label), final_answer);
     gtk_builder_connect_signals(builder, history_entry);
+    g_free(final_answer);
 }
 
 static void

--- a/src/math-history-entry.c
+++ b/src/math-history-entry.c
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2020 MATE developers
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version. See http://www.gnu.org/copyleft/gpl.html the full text of the
+ * license.
+ *
+ *
+ */
+
+#include <string.h>
+#include <glib/gi18n.h>
+#include <gdk/gdkkeysyms.h>
+
+#include "math-history-entry.h"
+
+struct MathHistoryEntryPrivate
+{
+    MathEquation *equation;
+
+    MPNumber *answer; /* Stores answer in MPNumber object */
+    char *equation_string; /* Stores equation to be entered in history-entry */
+    char *answer_string; /* Stores answer to be entered in history-entry */
+    GtkWidget *equation_label;
+    GtkWidget *answer_label;
+    GtkWidget *equation_eventbox;
+    GtkWidget *answer_eventbox;
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE (MathHistoryEntry, math_history_entry, GTK_TYPE_LIST_BOX_ROW);
+
+#define UI_HISTORY_ENTRY_RESOURCE_PATH "/org/mate/calculator/ui/history-entry.ui"
+#define GET_WIDGET(ui, name) \
+          GTK_WIDGET(gtk_builder_get_object(ui, name))
+
+MathHistoryEntry *
+math_history_entry_new(MathEquation *equation)
+{
+    MathHistoryEntry *history_entry = g_object_new(math_history_entry_get_type(), NULL);
+    history_entry->priv->equation = g_object_ref(equation);
+    return history_entry;
+}
+
+void answer_clicked_cb(GtkWidget *widget, GdkEventButton *eventbutton, gpointer data);
+G_MODULE_EXPORT
+void
+answer_clicked_cb (GtkWidget *widget, GdkEventButton *eventbutton, gpointer data)
+{   /* Callback function for button-press-event on answer_eventbox */
+    GtkEventBox *event = (GtkEventBox*) widget;
+    MathHistoryEntry *history_entry = MATH_HISTORY_ENTRY(data);
+    if (event != NULL)
+    {
+        if (GTK_IS_BIN(event))
+        {
+            GtkWidget *answer_label = gtk_bin_get_child(GTK_BIN(event));
+            char *answer = gtk_widget_get_tooltip_text(answer_label);
+            if (answer != NULL)
+                math_equation_insert(history_entry->priv->equation, answer);
+        }
+    }
+}
+void equation_clicked_cb(GtkWidget *widget, GdkEventButton *eventbutton,  gpointer data);
+G_MODULE_EXPORT
+void
+equation_clicked_cb (GtkWidget *widget, GdkEventButton *eventbutton, gpointer data)
+{   /* Callback function for button-press-event on equation_eventbox */
+    GtkEventBox *event = (GtkEventBox*) widget;
+    MathHistoryEntry *history_entry = MATH_HISTORY_ENTRY(data);
+    if (event != NULL)
+    {
+        if (GTK_IS_BIN(event))
+        {
+            GtkLabel *equation_label = (GtkLabel*) gtk_bin_get_child(GTK_BIN(event));
+            const char *equation = gtk_label_get_text(equation_label);
+            if (equation  != NULL)
+                math_equation_set(history_entry->priv->equation, equation);
+        }
+    }
+}
+
+void
+math_history_entry_insert_entry(MathHistoryEntry *history_entry, char *equation, MPNumber *number, int number_base)
+{
+    GtkBuilder *builder = NULL;
+    GtkWidget *grid;
+    GError *error = NULL;
+    char *final_answer;
+    MpSerializer *serializer_nine = mp_serializer_new(MP_DISPLAY_FORMAT_AUTOMATIC, number_base, 9);
+    MpSerializer *serializer_four = mp_serializer_new(MP_DISPLAY_FORMAT_AUTOMATIC, number_base, 4);
+
+    history_entry->priv->answer = number;
+    history_entry->priv->equation_string = equation;
+    history_entry->priv->answer_string = mp_serializer_to_string(serializer_nine, history_entry->priv->answer);
+    final_answer = mp_serializer_to_string(serializer_four, history_entry->priv->answer);
+    
+    builder = gtk_builder_new();
+    if(gtk_builder_add_from_resource (builder, UI_HISTORY_ENTRY_RESOURCE_PATH, &error) == 0)
+    {
+        g_print("gtk_builder_add_from_resource FAILED\n");
+        g_print("%s\n",error->message);
+        return;
+    }
+    grid = GET_WIDGET(builder, "grid");
+    gtk_container_add(GTK_CONTAINER(history_entry), grid);
+    history_entry->priv->equation_label = GET_WIDGET(builder, "equation_label");
+    history_entry->priv->answer_label = GET_WIDGET(builder, "answer_label");
+    history_entry->priv->equation_eventbox = GET_WIDGET(builder, "equation_eventbox");
+    history_entry->priv->answer_eventbox = GET_WIDGET(builder, "answer_eventbox");
+    gtk_widget_set_tooltip_text(history_entry->priv->equation_label, history_entry->priv->equation_string); 
+    gtk_widget_set_tooltip_text(history_entry->priv->answer_label, history_entry->priv->answer_string); 
+    gtk_label_set_text(GTK_LABEL(history_entry->priv->equation_label), history_entry->priv->equation_string);
+    gtk_label_set_text(GTK_LABEL(history_entry->priv->answer_label), final_answer);
+    gtk_builder_connect_signals(builder, history_entry);
+}
+
+static void
+math_history_entry_class_init(MathHistoryEntryClass *klass)
+{
+}
+
+static void
+math_history_entry_init(MathHistoryEntry *history_entry)
+{
+    history_entry->priv = math_history_entry_get_instance_private(history_entry);
+    history_entry->priv->equation_string = "";
+    history_entry->priv->answer_string = "";
+}

--- a/src/math-history-entry.h
+++ b/src/math-history-entry.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2020 MATE developers
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version. See http://www.gnu.org/copyleft/gpl.html the full text of the
+ * license.
+ *
+ *
+ */
+
+#ifndef MATH_HISTORY_ENTRY_VIEW_H
+#define MATH_HISTORY_ENTRY_VIEW_H
+
+#include <glib-object.h>
+#include <gtk/gtk.h>
+
+#include "math-display.h"
+#include "math-history.h"
+
+G_BEGIN_DECLS
+
+#define MATH_HISTORY_ENTRY(obj) (G_TYPE_CHECK_INSTANCE_CAST ((obj), math_history_entry_get_type(), MathHistoryEntry))
+
+typedef struct MathHistoryEntryPrivate MathHistoryEntryPrivate;
+
+typedef struct
+{
+    GtkListBoxRow parent_instance;
+    MathHistoryEntryPrivate *priv;
+} MathHistoryEntry;
+
+typedef struct
+{
+    GtkListBoxRowClass parent_class;
+} MathHistoryEntryClass;
+
+GType math_history_entry_get_type(void);
+
+MathHistoryEntry *
+math_history_entry_new(MathEquation *equation);
+
+void
+math_history_entry_insert_entry(MathHistoryEntry *history_entry, char *equation, MPNumber *number, int number_base);
+
+G_END_DECLS
+
+#endif /* MATH_HISTORY_ENTRY_VIEW_H */

--- a/src/math-history.c
+++ b/src/math-history.c
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2020 MATE developers
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version. See http://www.gnu.org/copyleft/gpl.html the full text of the
+ * license.
+ *
+ *
+ */
+
+#include <string.h>
+#include <glib/gi18n.h>
+#include <gdk/gdkkeysyms.h>
+
+#include "math-history.h"
+
+struct MathHistoryPrivate
+{
+    MathEquation *equation;
+
+    MathHistoryEntry *entry;
+    char *prev_equation;
+    int items_count; /* Number of entries in history listbox */
+    GtkWidget *listbox;
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE(MathHistory, math_history, GTK_TYPE_SCROLLED_WINDOW);
+
+MathHistory *
+math_history_new(MathEquation *equation)
+{
+    MathHistory *history = g_object_new(math_history_get_type(), NULL);
+    history->priv->equation = g_object_ref(equation);
+    return history;
+}
+
+static void
+scroll_bottom_cb(MathHistory *history, gpointer data)
+{
+    GtkAdjustment *adjustment;
+    // TODO make this dynamic, do not hardcode listbox_height_request/number_of_rows
+    int width, height;
+
+    adjustment = gtk_list_box_get_adjustment(GTK_LIST_BOX(history->priv->listbox));
+    gtk_widget_get_size_request(GTK_WIDGET(history), &width, &height);
+    gtk_adjustment_set_page_size(adjustment, height / 3);
+    gtk_adjustment_set_value (adjustment, gtk_adjustment_get_upper (adjustment)
+                                          - gtk_adjustment_get_page_size (adjustment));
+}
+
+static gboolean
+check_history(MathHistory *history, char *equation)
+{ /* Checks if the last inserted calculation is the same as the current calculation to be inserted in history-history */
+    if (history->priv->items_count >= 1 && g_strcmp0(equation, history->priv->prev_equation)==0)
+        return TRUE; /* returns true if last entered equation is the same as the current equation */
+    else
+        return FALSE;
+}
+
+void
+math_history_insert_entry (MathHistory *history, char *equation, MPNumber *answer, int number_base)
+{   /* Inserts a new entry into the history-history listbox */
+    history->priv->entry = math_history_entry_new(history->priv->equation);
+    gboolean check = check_history (history, equation);
+    history->priv->prev_equation = g_strdup(equation);
+    if (!check)
+    {
+        math_history_entry_insert_entry(history->priv->entry, equation, answer, number_base);
+        if (history->priv->entry != NULL)	
+        {
+            gtk_list_box_insert(GTK_LIST_BOX(history->priv->listbox), GTK_WIDGET(history->priv->entry), -1);
+            gtk_widget_set_can_focus(GTK_WIDGET(history->priv->entry), FALSE);
+            gtk_widget_show_all(GTK_WIDGET(history->priv->entry));	
+            history->priv->items_count++;
+        }
+    }
+    g_signal_emit_by_name(history, "row-added");
+}
+
+static void
+math_history_class_init(MathHistoryClass *klass)
+{
+    g_signal_new("row-added",
+                 G_TYPE_FROM_CLASS(klass),
+                 G_SIGNAL_RUN_FIRST,
+                 0,
+                 NULL,
+                 NULL,
+                 NULL,
+                 G_TYPE_NONE,
+                 0,
+                 NULL);
+}
+
+static void
+math_history_init(MathHistory *history)
+{
+    history->priv = math_history_get_instance_private(history);
+    gtk_scrolled_window_set_shadow_type(GTK_SCROLLED_WINDOW(history), GTK_SHADOW_IN);
+    gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(history), GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
+    gtk_scrolled_window_set_placement(GTK_SCROLLED_WINDOW(history), GTK_CORNER_TOP_LEFT);
+
+    history->priv->items_count = 0;
+    history->priv->prev_equation = "";
+    history->priv->listbox = gtk_list_box_new();    
+    gtk_list_box_set_selection_mode(GTK_LIST_BOX(history->priv->listbox), GTK_SELECTION_NONE);
+    gtk_widget_show(GTK_WIDGET(history->priv->listbox));
+
+    gtk_container_add(GTK_CONTAINER(history), history->priv->listbox);
+    gtk_widget_set_valign(GTK_WIDGET(history->priv->listbox), GTK_ALIGN_END);
+    gtk_widget_set_size_request(GTK_WIDGET(history), 100, 100);
+    gtk_widget_set_can_focus(GTK_WIDGET(history), FALSE);
+
+    g_signal_connect(history, "row-added", G_CALLBACK(scroll_bottom_cb), NULL);
+}

--- a/src/math-history.c
+++ b/src/math-history.c
@@ -52,7 +52,7 @@ scroll_bottom_cb(MathHistory *history, gpointer data)
 
 static gboolean
 check_history(MathHistory *history, char *equation)
-{ /* Checks if the last inserted calculation is the same as the current calculation to be inserted in history-history */
+{ /* Checks if the last inserted calculation is the same as the current calculation to be inserted in history */
     if (history->priv->items_count >= 1 && g_strcmp0(equation, history->priv->prev_equation)==0)
         return TRUE; /* returns true if last entered equation is the same as the current equation */
     else
@@ -61,7 +61,7 @@ check_history(MathHistory *history, char *equation)
 
 void
 math_history_insert_entry (MathHistory *history, char *equation, MPNumber *answer, int number_base)
-{   /* Inserts a new entry into the history-history listbox */
+{   /* Inserts a new entry into the history listbox */
     history->priv->entry = math_history_entry_new(history->priv->equation);
     gboolean check = check_history (history, equation);
     history->priv->prev_equation = g_strdup(equation);

--- a/src/math-history.h
+++ b/src/math-history.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2020 MATE developers
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version. See http://www.gnu.org/copyleft/gpl.html the full text of the
+ * license.
+ *
+ *
+ */
+
+#ifndef MATH_HISTORY_VIEW_H
+#define MATH_HISTORY_VIEW_H
+
+#include <glib-object.h>
+#include <gtk/gtk.h>
+
+#include "math-history-entry.h"
+#include "math-display.h"
+#include "math-equation.h"
+
+G_BEGIN_DECLS
+
+#define MATH_HISTORY(obj) (G_TYPE_CHECK_INSTANCE_CAST ((obj), math_history_get_type(), MathHistory))
+
+typedef struct MathHistoryPrivate MathHistoryPrivate;
+
+typedef struct
+{
+    GtkScrolledWindow parent_instance;
+    MathHistoryPrivate *priv;
+} MathHistory;
+
+typedef struct
+{
+    GtkScrolledWindowClass parent_class;
+} MathHistoryClass;
+
+GType math_history_get_type(void);
+
+MathHistory *
+math_history_new(MathEquation *equation);
+
+void
+math_history_insert_entry(MathHistory *history, char *equation, MPNumber *answer, int number_base);
+
+G_END_DECLS
+
+#endif /* MATH_HISTORY_VIEW_H */

--- a/src/math-window.h
+++ b/src/math-window.h
@@ -49,6 +49,10 @@ MathDisplay *math_window_get_display(MathWindow *window);
 
 MathButtons *math_window_get_buttons(MathWindow *window);
 
+gboolean math_window_get_show_history(MathWindow *window);
+
+void math_window_set_show_history(MathWindow *window, gboolean visible);
+
 void math_window_critical_error(MathWindow *window, const gchar *title, const gchar *contents);
 
 G_END_DECLS

--- a/src/org.mate.calculator.gresource.xml
+++ b/src/org.mate.calculator.gresource.xml
@@ -23,5 +23,6 @@
     <file compressed="true" preprocess="xml-stripblanks">buttons-programming.ui</file>
     <file compressed="true">mate-calc.about</file>
     <file compressed="true" preprocess="xml-stripblanks">preferences.ui</file>
+    <file compressed="true" preprocess="xml-stripblanks">history-entry.ui</file>
   </gresource>
 </gresources>


### PR DESCRIPTION
So this lets mate-calc as it is. It just adds the option to show the history if desired by the user (menu->View->History or ctrl+h).
- adds history view to show recent calculations.
- adds an option to enable/disable history (disabled by default).
- adds the possibility to resize mate-calc if history is enabled.

Closes #32 and closes #42 and closes #131 