### PR TITLE
add modular exponentiation ability and add acccording tests

### DIFF
--- a/src/mp.c
+++ b/src/mp.c
@@ -580,9 +580,9 @@ mp_modular_exponentiation(const MPNumber *x, const MPNumber *y, const MPNumber *
     mp_modulus_divide(&ans, p, z);
 
     mp_clear(&base_value);
-	mp_clear(&exp_value);
-	mp_clear(&ans);
-	mp_clear(&two);
+    mp_clear(&exp_value);
+    mp_clear(&ans);
+    mp_clear(&two);
     mp_clear(&tmp);
 }
 

--- a/src/mp.h
+++ b/src/mp.h
@@ -204,6 +204,9 @@ void   mp_factorial(const MPNumber *x, MPNumber *z);
 /* Sets z = x mod y */
 void   mp_modulus_divide(const MPNumber *x, const MPNumber *y, MPNumber *z);
 
+/* Sets z = x ^ y mod p */
+void mp_modular_exponentiation(const MPNumber *x, const MPNumber *y, const MPNumber *p, MPNumber *z);
+
 /* Sets z = x^y */
 void   mp_xpowy(const MPNumber *x, const MPNumber *y, MPNumber *z);
 

--- a/src/parserfunc.c
+++ b/src/parserfunc.c
@@ -674,7 +674,26 @@ pf_do_mod(ParseNode* self)
         free(ans);
         return NULL;
     }
-    mp_modulus_divide(left, right, ans);
+    if (self->left->evaluate == pf_do_x_pow_y)
+    {
+        MPNumber* base_value = (MPNumber*) (*(self->left->left->evaluate))(self->left->left);
+        MPNumber* exponent = (MPNumber*) (*(self->left->right->evaluate))(self->left->right);
+        if(!base_value || !exponent)
+        {
+            if(base_value)
+                mp_free(base_value);
+            if(exponent)
+                mp_free(exponent);
+            free(ans);
+            return NULL;
+        }
+        mp_modular_exponentiation(base_value, exponent, right, ans);
+        mp_free(base_value);
+        mp_free(exponent);
+    }
+    else
+        mp_modulus_divide(left, right, ans);
+
     mp_free(left);
     mp_free(right);
     return ans;
@@ -752,7 +771,7 @@ pf_do_add(ParseNode* self)
     return ans;
 }
 
-/*Add (x) Percentage to value. */
+/* Add (x) Percentage to value. */
 void*
 pf_do_add_percent(ParseNode* self)
 {

--- a/src/parserfunc.c
+++ b/src/parserfunc.c
@@ -671,7 +671,7 @@ pf_do_mod(ParseNode* self)
             mp_free(left);
         if(right)
             mp_free(right);
-        free(ans);
+        mp_free(ans);
         return NULL;
     }
     if (self->left->evaluate == pf_do_x_pow_y)
@@ -684,7 +684,7 @@ pf_do_mod(ParseNode* self)
                 mp_free(base_value);
             if(exponent)
                 mp_free(exponent);
-            free(ans);
+            mp_free(ans);
             return NULL;
         }
         mp_modular_exponentiation(base_value, exponent, right, ans);

--- a/src/test-mp-equation.c
+++ b/src/test-mp-equation.c
@@ -478,6 +478,11 @@ test_equations(void)
     test("8 mod 7", "1", 0);
     test("−1 mod 7", "6", 0);
 
+    test("123^456 mod 78", "27", 0);
+    test("2^2 mod 2", "0", 0);
+    test("1^0 mod 2", "1", 0);
+    test("2^1 mod 1", "0", 0);
+
     test("sgn 0", "0", 0);
     test("sgn 3", "1", 0);
     test("sgn −3", "−1", 0);


### PR DESCRIPTION
Adds a new feature, the square and multiply algorithm, to calculate  `z = x^y mod p` really fast and correct. On the way I fixed a problem in `mp_modulus_divide` where calling it with equal arguments `z=x` like `mp_modulus_divide(x, p, x)` would not work. Inspired by gnome-calculators implementation (https://gitlab.gnome.org/GNOME/gnome-calculator/-/commit/5a4b32820877517eee1ebd6928a3a649f76aab2a).

Test:
Before PR:
`123^456mod78 = 0` (is wrong)
`123^456789mod10 = 0` (is wrong)
After PR:
`123^456mod78 = 27`
`123^456789mod10 = 3`
You can verify results with python console:
```
>>> pow(123,456,78)
27
```

You can even try very long numbers, like `123123123123123123123123123123123123123123123123123123123123^123123123123123123456789mod12312312312312312312312312312312312312312312312312310`
which is especially useful for some basic cryptography.