### PR TITLE
build: Remove redundant LDFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -44,8 +44,6 @@ GLIB_MKENUMS=`$PKG_CONFIG --variable=glib_mkenums glib-2.0`
 AC_SUBST(GLIB_MKENUMS)
 
 AC_CHECK_LIB(m, log)
-AC_CHECK_LIB(gmp, log)
-AC_CHECK_LIB(mpfr, log)
 AC_CHECK_LIB(mpc, log)
 
 dnl ###########################################################################

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -72,7 +72,7 @@ mate_calc_SOURCES = \
 	utility.h
 
 mate_calc_LDADD = \
-	$(MATE_CALC_LIBS)        
+	$(MATE_CALC_LIBS)
 
 mate_calc_cmd_SOURCES = \
 	mate-calc-cmd.c \
@@ -105,11 +105,7 @@ mate_calc_cmd_SOURCES = \
 	parser.h
 
 mate_calc_cmd_LDADD = \
-	$(MATE_CALC_CMD_LIBS) \
-	-lm \
-	-lgmp \
-	-lmpfr \
-	-lmpc
+	$(MATE_CALC_CMD_LIBS)
 
 test_mp_SOURCES = \
 	test-mp.c \
@@ -123,11 +119,7 @@ test_mp_SOURCES = \
 	mp-trigonometric.c
 
 test_mp_LDADD = \
-	$(MATE_CALC_CMD_LIBS) \
-	-lm \
-	-lgmp \
-	-lmpfr \
-	-lmpc
+	$(MATE_CALC_CMD_LIBS)
 
 test_mp_equation_SOURCES = \
 	test-mp-equation.c \
@@ -160,11 +152,7 @@ test_mp_equation_SOURCES = \
 	parser.h
 
 test_mp_equation_LDADD = \
-	$(MATE_CALC_CMD_LIBS) \
-	-lm \
-	-lgmp \
-	-lmpfr \
-	-lmpc
+	$(MATE_CALC_CMD_LIBS)
 
 CLEANFILES = \
 	mp-enums.c \


### PR DESCRIPTION
Test:
```shell
$ pkg-config --libs mpfr
-lmpfr -lgmp
```
Test 2:
```shell
$ ./autogen.sh --prefix=/usr && make V=1 &> make.log
$ grep lmpfr make.log
gcc  -g -O2   -o mate-calc mate-calc.o currency.o currency-manager.o math-buttons.o math-converter.o math-history.o math-history-entry.o math-display.o math-equation.o math-preferences.o math-variables.o math-variable-popup.o math-window.o mp.o mp-binary.o mp-convert.o mp-enums.o mp-equation.o mp-serializer.o mp-trigonometric.o financial.o unit.o unit-category.o unit-manager.o prelexer.o lexer.o parserfunc.o parser.o mate-calc-resources.o -lgtk-3 -lgdk-3 -lpangocairo-1.0 -lpango-1.0 -lharfbuzz -latk-1.0 -lcairo-gobject -lcairo -lgdk_pixbuf-2.0 -lgio-2.0 -lgobject-2.0 -lmpfr -lgmp -lxml2 -Wl,--export-dynamic -lgmodule-2.0 -pthread -lglib-2.0 -lglib-2.0          -lmpc -lmpfr -lgmp -lm 
gcc  -g -O2   -o mate-calc-cmd mate-calc-cmd.o currency.o currency-manager.o mp.o mp-binary.o mp-convert.o mp-enums.o mp-equation.o mp-serializer.o mp-trigonometric.o unit.o unit-category.o unit-manager.o prelexer.o lexer.o parserfunc.o parser.o -lgio-2.0 -lgobject-2.0 -lglib-2.0 -lmpfr -lgmp -lxml2  -lm -lgmp -lmpfr -lmpc -lmpc -lmpfr -lgmp -lm 
gcc  -g -O2   -o test-mp test-mp.o mp.o mp-binary.o mp-convert.o mp-enums.o mp-serializer.o mp-trigonometric.o -lgio-2.0 -lgobject-2.0 -lglib-2.0 -lmpfr -lgmp -lxml2  -lm -lgmp -lmpfr -lmpc -lmpc -lmpfr -lgmp -lm 
gcc  -g -O2   -o test-mp-equation test-mp-equation.o currency.o currency-manager.o mp.o mp-convert.o mp-binary.o mp-enums.o mp-equation.o mp-serializer.o mp-trigonometric.o unit.o unit-category.o unit-manager.o prelexer.o lexer.o parserfunc.o parser.o -lgio-2.0 -lgobject-2.0 -lglib-2.0 -lmpfr -lgmp -lxml2  -lm -lgmp -lmpfr -lmpc -lmpc -lmpfr -lgmp -lm 
```