### PR TITLE
set bottom margin to 12 for gtk widget info_view

### DIFF
--- a/src/math-display.c
+++ b/src/math-display.c
@@ -398,6 +398,7 @@ create_gui(MathDisplay *display)
     gtk_text_view_set_cursor_visible(GTK_TEXT_VIEW(info_view), FALSE); // FIXME: Just here so when incorrectly gets focus doesn't look editable
     gtk_text_view_set_editable(GTK_TEXT_VIEW(info_view), FALSE);
     gtk_text_view_set_justification(GTK_TEXT_VIEW(info_view), GTK_JUSTIFY_RIGHT);
+    gtk_text_view_set_bottom_margin(GTK_TEXT_VIEW(info_view), 12);
     /* TEMP: Disabled for now as GTK+ doesn't properly render a right aligned right margin, see bug #482688 */
     /*gtk_text_view_set_right_margin(GTK_TEXT_VIEW(info_view), 6);*/
     gtk_box_pack_start(GTK_BOX(info_box), info_view, TRUE, TRUE, 0);


### PR DESCRIPTION
Notification area is hidden under scrollbar currently.
Before:
![Screenshot at 2020-03-16 14-08-09](https://user-images.githubusercontent.com/39454100/76761681-2ad86e00-6790-11ea-8510-8e34197ebe78.png)
After:
![Screenshot at 2020-03-16 14-08-53](https://user-images.githubusercontent.com/39454100/76761688-2e6bf500-6790-11ea-9b79-cb6d0225cfed.png)
