### PR TITLE
test-mp-equation: Fix memory leak

### DIFF
--- a/src/test-mp-equation.c
+++ b/src/test-mp-equation.c
@@ -77,9 +77,12 @@ static void
 Test(char *expression, char *expected, int expected_error, int trailing_digits)
 {
     MPErrorCode error;
+    char *error_token = NULL;
     MPNumber result = mp_new();
 
-    error = mp_equation_parse(expression, &options, &result, NULL);
+    error = mp_equation_parse(expression, &options, &result, &error_token);
+    if (error_token)
+        g_free (error_token);
 
     if (error == 0) {
         char *result_str;


### PR DESCRIPTION
Test:
```shell
$ CFLAGS="-ggdb3 -O0 -fsanitize=address" ./autogen.sh --prefix=/usr && make
$ ./src/test-mp-equation 
Passed all 445 tests

=================================================================
==72013==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 206176 byte(s) in 1516 object(s) allocated from:
    #0 0x7f4fc6c6b6b7 in __interceptor_malloc (/lib64/libasan.so.6+0xb06b7)
    #1 0x7f4fc673e8ed in __gmp_default_allocate (/lib64/libgmp.so.10+0x118ed)

Direct leak of 5745 byte(s) in 1305 object(s) allocated from:
    #0 0x7f4fc6c6b6b7 in __interceptor_malloc (/lib64/libasan.so.6+0xb06b7)
    #1 0x7f4fc68ac898 in g_malloc (/lib64/libglib-2.0.so.0+0x58898)

Direct leak of 64 byte(s) in 1 object(s) allocated from:
    #0 0x7f4fc6c6b6b7 in __interceptor_malloc (/lib64/libasan.so.6+0xb06b7)
    #1 0x40b850 in mp_new_ptr /home/robert/mate-calc/src/mp.c:68
    #2 0x4290eb in pf_do_x_pow_y_int /home/robert/mate-calc/src/parserfunc.c:588
    #3 0x429307 in pf_do_x_pow_y_int /home/robert/mate-calc/src/parserfunc.c:600
    #4 0x42b87e in p_parse /home/robert/mate-calc/src/parser.c:276
    #5 0x4144f2 in mp_equation_parse /home/robert/mate-calc/src/mp-equation.c:313
    #6 0x405111 in Test /home/robert/mate-calc/src/test-mp-equation.c:83
    #7 0x406de7 in test_equations /home/robert/mate-calc/src/test-mp-equation.c:441
    #8 0x40813b in main /home/robert/mate-calc/src/test-mp-equation.c:684
    #9 0x7f4fc62b5041 in __libc_start_main (/lib64/libc.so.6+0x27041)

Indirect leak of 272 byte(s) in 2 object(s) allocated from:
    #0 0x7f4fc6c6b6b7 in __interceptor_malloc (/lib64/libasan.so.6+0xb06b7)
    #1 0x7f4fc673e8ed in __gmp_default_allocate (/lib64/libgmp.so.10+0x118ed)

SUMMARY: AddressSanitizer: 212257 byte(s) leaked in 2824 allocation(s).
```