### PR TITLE
parserfunc: fix memory leak

### DIFF
--- a/src/parserfunc.c
+++ b/src/parserfunc.c
@@ -595,9 +595,15 @@ pf_do_x_pow_y_int(ParseNode* self)
     }
 
     if (self->right->token != NULL)
+    {
         pow = super_atoi(self->right->token->string);
+    }
     else
-        pow = mp_to_integer((MPNumber*) (*(self->right->evaluate))(self->right));
+    {
+        MPNumber* aux = (MPNumber*) (*(self->right->evaluate))(self->right);
+        pow = mp_to_integer(aux);
+        mp_free(aux);
+    }
 
     if(!val)
     {


### PR DESCRIPTION
Test:
```
$ CFLAGS="-ggdb3 -O0 -fsanitize=address" ./autogen.sh --prefix=/usr && make
$ ./src/test-mp-equation
```
master
```
SUMMARY: AddressSanitizer: 212469 byte(s) leaked in 2878 allocation(s).
```
PR
```
SUMMARY: AddressSanitizer: 212133 byte(s) leaked in 2875 allocation(s).
```