### PR TITLE
history-view: simplify code and add clear option

### DIFF
--- a/src/math-history-entry.h
+++ b/src/math-history-entry.h
@@ -42,7 +42,7 @@ MathHistoryEntry *
 math_history_entry_new(MathEquation *equation);
 
 void
-math_history_entry_insert_entry(MathHistoryEntry *history_entry, char *equation, MPNumber *number, int number_base);
+math_history_entry_insert_entry(MathHistoryEntry *history_entry, const gchar *equation, const gchar *answer_four_digits, const gchar *answer_nine_digits);
 
 G_END_DECLS
 

--- a/src/math-history.h
+++ b/src/math-history.h
@@ -45,6 +45,9 @@ math_history_new(MathEquation *equation);
 void
 math_history_insert_entry(MathHistory *history, char *equation, MPNumber *answer, int number_base);
 
+void
+math_history_clear(MathHistory *history);
+
 G_END_DECLS
 
 #endif /* MATH_HISTORY_VIEW_H */

--- a/src/math-window.c
+++ b/src/math-window.c
@@ -180,6 +180,11 @@ static void show_history_cb(MathWindow *window, GParamSpec *spec)
     g_settings_set_boolean(g_settings_var, "show-history", math_window_get_show_history(window));
 }
 
+static void clear_history_cb(GtkMenuItem *menu, MathWindow *window)
+{
+    math_history_clear(window->priv->history);
+}
+
 static void show_preferences_cb(GtkMenuItem *menu, MathWindow *window)
 {
     if (!window->priv->preferences_dialog)
@@ -509,6 +514,8 @@ static void create_menu(MathWindow* window)
     gtk_widget_add_accelerator(menu_item, "activate", accel_group, GDK_KEY_Z, GDK_CONTROL_MASK, GTK_ACCEL_VISIBLE);
     menu_item = add_menu_item(menu, gtk_image_menu_item_new_from_icon("edit-redo",_("_Redo"), accel_group), G_CALLBACK(redo_cb), window);
     gtk_widget_add_accelerator(menu_item, "activate", accel_group, GDK_KEY_Z, GDK_CONTROL_MASK | GDK_SHIFT_MASK, GTK_ACCEL_VISIBLE);
+    menu_item = add_menu_item(menu, gtk_image_menu_item_new_from_icon("edit-clear",_("_Clear History"), accel_group), G_CALLBACK(clear_history_cb), window);
+    gtk_widget_add_accelerator(menu_item, "activate", accel_group, GDK_KEY_Delete, GDK_CONTROL_MASK | GDK_SHIFT_MASK, GTK_ACCEL_VISIBLE);
     add_menu_item(menu, gtk_separator_menu_item_new(), NULL, NULL);
     add_menu_item(menu, gtk_image_menu_item_new_from_icon("preferences-desktop",_("_Preferences"), accel_group), G_CALLBACK(show_preferences_cb), window);
     add_menu_item(menu, gtk_separator_menu_item_new(), NULL, NULL);


### PR DESCRIPTION
Inspired by `gnome-calculators` implementation. If this PR gets merged, it would make #139 obsolete. If you want, I can change the "Clear History" shortcut and menu item, I took Shift+Ctrl+C for now.
![Screenshot at 2020-03-23 00-28-50](https://user-images.githubusercontent.com/39454100/77265573-57fbb380-6c9d-11ea-8885-52970ea456cf.png)
EDIT: Just noticed that Shift+Ctrl+C may be a bad idea, because some are used to copy like this from a terminal window. Maybe Ctrl+ESC would be more appropriate?
