### PR TITLE
math-display: set justification to left and add margin

### DIFF
--- a/src/math-display.c
+++ b/src/math-display.c
@@ -374,9 +374,8 @@ create_gui(MathDisplay *display)
     gtk_text_view_set_accepts_tab(GTK_TEXT_VIEW(display->priv->text_view), FALSE);
     gtk_text_view_set_pixels_above_lines(GTK_TEXT_VIEW(display->priv->text_view), 8);
     gtk_text_view_set_pixels_below_lines(GTK_TEXT_VIEW(display->priv->text_view), 2);
-    /* TEMP: Disabled for now as GTK+ doesn't properly render a right aligned right margin, see bug #482688 */
-    /*gtk_text_view_set_right_margin(GTK_TEXT_VIEW(display->priv->text_view), 6);*/
-    gtk_text_view_set_justification(GTK_TEXT_VIEW(display->priv->text_view), GTK_JUSTIFY_RIGHT);
+    gtk_text_view_set_left_margin(GTK_TEXT_VIEW(display->priv->text_view), 6);
+    gtk_text_view_set_justification(GTK_TEXT_VIEW(display->priv->text_view), GTK_JUSTIFY_LEFT);
     context = gtk_widget_get_style_context (display->priv->text_view);
     state = gtk_widget_get_state_flags (GTK_WIDGET (display->priv->text_view));
     gtk_style_context_get (context, state, GTK_STYLE_PROPERTY_FONT, &font_desc, NULL);
@@ -394,13 +393,11 @@ create_gui(MathDisplay *display)
 
     info_view = gtk_text_view_new();
     gtk_text_view_set_wrap_mode(GTK_TEXT_VIEW(info_view), GTK_WRAP_WORD);
-    gtk_widget_set_can_focus(info_view, TRUE); // FIXME: This should be FALSE but it locks the cursor inside the main view for some reason
-    gtk_text_view_set_cursor_visible(GTK_TEXT_VIEW(info_view), FALSE); // FIXME: Just here so when incorrectly gets focus doesn't look editable
+    gtk_widget_set_can_focus(GTK_WIDGET(info_view), FALSE);
     gtk_text_view_set_editable(GTK_TEXT_VIEW(info_view), FALSE);
     gtk_text_view_set_justification(GTK_TEXT_VIEW(info_view), GTK_JUSTIFY_RIGHT);
     gtk_text_view_set_bottom_margin(GTK_TEXT_VIEW(info_view), 12);
-    /* TEMP: Disabled for now as GTK+ doesn't properly render a right aligned right margin, see bug #482688 */
-    /*gtk_text_view_set_right_margin(GTK_TEXT_VIEW(info_view), 6);*/
+    gtk_text_view_set_right_margin(GTK_TEXT_VIEW(info_view), 6);
     gtk_box_pack_start(GTK_BOX(info_box), info_view, TRUE, TRUE, 0);
     display->priv->info_buffer = gtk_text_view_get_buffer(GTK_TEXT_VIEW(info_view));
 


### PR DESCRIPTION
In most languages it is common to write from left to right and even most modern physical calculators are justified to the left. I tested it with many different themes and it seems to work fine.