### PR TITLE
math-buttons: add space character after inverse trig. functions

### DIFF
--- a/src/math-buttons.c
+++ b/src/math-buttons.c
@@ -180,13 +180,13 @@ static ButtonData button_data[] = {
     {"hyperbolic_tangent", "tanh ", FUNCTION,
       /* Tooltip for the hyperbolic tangent button */
       N_("Hyperbolic Tangent")},
-    {"inverse_sine", "asin", FUNCTION,
+    {"inverse_sine", "asin ", FUNCTION,
       /* Tooltip for the inverse sine button */
       N_("Inverse Sine")},
-    {"inverse_cosine", "acos", FUNCTION,
+    {"inverse_cosine", "acos ", FUNCTION,
       /* Tooltip for the inverse cosine button */
       N_("Inverse Cosine")},
-    {"inverse_tangent", "atan", FUNCTION,
+    {"inverse_tangent", "atan ", FUNCTION,
       /* Tooltip for the inverse tangent button */
       N_("Inverse Tangent")},
     {"inverse",            "⁻¹", FUNCTION,


### PR DESCRIPTION
As it is with all other functions in order to press button and enter function argument, without having to press space bar.
This is a problem if function argument is a variable or the last answer (which internally is a variable).
Test: Press "asin" and "pi" button for example.