### PR TITLE
Remove -Wshadow warnings

### DIFF
--- a/src/mate-calc.c
+++ b/src/mate-calc.c
@@ -183,7 +183,7 @@ get_options(int argc, char *argv[])
 }
 
 static void
-quit_cb(MathWindow *window)
+quit_cb(MathWindow *win)
 {
     gtk_main_quit();
 }

--- a/src/math-buttons.c
+++ b/src/math-buttons.c
@@ -393,13 +393,13 @@ update_bit_panel(MathButtons *buttons)
         return;
 
     for (i = 0; i < MAXBITS; i++) {
-        const gchar *label;
+        const gchar *bin_label;
 
         if (bits & (1LLU << (MAXBITS-i-1)))
-            label = " 1";
+            bin_label = " 1";
         else
-            label = " 0";
-        gtk_label_set_text(GTK_LABEL(buttons->priv->bit_labels[i]), label);
+            bin_label = " 0";
+        gtk_label_set_text(GTK_LABEL(buttons->priv->bit_labels[i]), bin_label);
     }
 
     base = math_equation_get_base(buttons->priv->equation);

--- a/src/math-converter.c
+++ b/src/math-converter.c
@@ -145,10 +145,10 @@ update_from_model(MathConverter *converter)
 
             for (unit_iter = unit_category_get_units(category); unit_iter; unit_iter = unit_iter->next) {
                 Unit *unit = unit_iter->data;
-                GtkTreeIter iter;
+                GtkTreeIter iter_new_row;
 
-                gtk_tree_store_append(from_model, &iter, &parent);
-                gtk_tree_store_set(from_model, &iter, 0, unit_get_display_name(unit), 1, category, 2, unit, -1);
+                gtk_tree_store_append(from_model, &iter_new_row, &parent);
+                gtk_tree_store_set(from_model, &iter_new_row, 0, unit_get_display_name(unit), 1, category, 2, unit, -1);
             }
         }
     }

--- a/src/math-variable-popup.c
+++ b/src/math-variable-popup.c
@@ -204,10 +204,10 @@ math_variable_popup_set_property(GObject      *object,
 
         names = math_variables_get_names(math_equation_get_variables(self->priv->equation));
         for (i = 0; names[i]; i++) {
-            MPNumber *value;
+            MPNumber *aux;
 
-            value = math_variables_get(math_equation_get_variables(self->priv->equation), names[i]);
-            entry = make_variable_entry(self, names[i], value, TRUE);
+            aux = math_variables_get(math_equation_get_variables(self->priv->equation), names[i]);
+            entry = make_variable_entry(self, names[i], aux, TRUE);
             gtk_widget_show(entry);
             gtk_box_pack_start(GTK_BOX(self->priv->vbox), entry, FALSE, TRUE, 0);
         }

--- a/src/mp-serializer.c
+++ b/src/mp-serializer.c
@@ -159,7 +159,7 @@ mp_to_string_real(MpSerializer *serializer, const MPNumber *x, int base, gboolea
 
     /* Append base suffix if not in default base */
     if (base != serializer->priv->base) {
-        const gchar *digits[] = {"₀", "₁", "₂", "₃", "₄", "₅", "₆", "₇", "₈", "₉"};
+        const gchar *base_digits[] = {"₀", "₁", "₂", "₃", "₄", "₅", "₆", "₇", "₈", "₉"};
         int multiplier = 1;
         int b = base;
 
@@ -169,7 +169,7 @@ mp_to_string_real(MpSerializer *serializer, const MPNumber *x, int base, gboolea
             int d;
             multiplier /= 10;
             d = b / multiplier;
-            g_string_append(string, digits[d]);
+            g_string_append(string, base_digits[d]);
             b -= d * multiplier;
         }
     }


### PR DESCRIPTION
```
mate-calc.c:186:21: warning: declaration of ‘window’ shadows a global declaration [-Wshadow]
  186 | quit_cb(MathWindow *window)
      |         ~~~~~~~~~~~~^~~~~~
--
math-buttons.c:396:22: warning: declaration of ‘label’ shadows a previous local [-Wshadow]
  396 |         const gchar *label;
      |                      ^~~~~
--
math-converter.c:148:29: warning: declaration of ‘iter’ shadows a previous local [-Wshadow]
  148 |                 GtkTreeIter iter;
      |                             ^~~~
--
math-variable-popup.c:207:23: warning: declaration of ‘value’ shadows a parameter [-Wshadow]
  207 |             MPNumber *value;
      |                       ^~~~~
--
mp-serializer.c:162:22: warning: declaration of ‘digits’ shadows a previous local [-Wshadow]
  162 |         const gchar *digits[] = {"₀", "₁", "₂", "₃", "₄", "₅", "₆", "₇", "₈", "₉"};
      |                      ^~~~~~
```