### PR TITLE
math-equation: Fix memory leak

### DIFF
--- a/src/math-equation.c
+++ b/src/math-equation.c
@@ -998,6 +998,7 @@ math_equation_set_number(MathEquation *equation, const MPNumber *x)
     equation->priv->ans_end = gtk_text_buffer_create_mark(GTK_TEXT_BUFFER(equation), NULL, &end, TRUE);
     gtk_text_buffer_apply_tag(GTK_TEXT_BUFFER(equation), equation->priv->ans_tag, &start, &end);
     g_free(text);
+    free_state(state);
 }
 
 


### PR DESCRIPTION
LeakSanitizer detected memory leaks:
```
Direct leak of 104 byte(s) in 1 object(s) allocated from:
    #0 0x418c85 in __interceptor_calloc.part.0 (/usr/bin/mate-calc+0x418c85)
    #1 0x7f587f9be9d0 in g_malloc0 (/lib64/libglib-2.0.so.0+0x589d0)
    #2 0x44956e in math_equation_set_number /home/robert/sanitizer/mate-calc/src/math-equation.c:986:13
    #3 0x44a04b in math_equation_look_for_answer /home/robert/sanitizer/mate-calc/src/math-equation.c:1307:9
    #4 0x7f587f9b9350  (/lib64/libglib-2.0.so.0+0x53350)
```
Test:
```
  CFLAGS="-fsanitize=leak -fno-omit-frame-pointer -g -ggdb3 -O0"
  LDFLAGS="-fsanitize=leak -ggdb3"
  CONF="--prefix=/usr"
  
$ CC="clang" CXX="clang++" CFLAGS="${CFLAGS}" ./autogen.sh ${CONF} && make

```