### PR TITLE
Implemented navigation through history stack equations using keyboard

### DIFF
--- a/help/C/keyboard.page
+++ b/help/C/keyboard.page
@@ -39,4 +39,38 @@
     <p>
     To enter <link xref="superscript">superscript numbers</link> use <keyseq><key>Ctrl</key>number</keyseq>, for subscript use <keyseq><key>Alt</key>number</keyseq>.
     </p>
+    <p>
+    When in <link xref="mouse">programming mode</link>, to cycle between base digits use:
+    </p>
+    <table>
+    <tr>
+    <td><p>Binary</p></td>
+    <td><p><keyseq><key>Ctrl</key><key>B</key></keyseq></p></td>
+    </tr>
+    <tr>
+    <td><p>Octal</p></td>
+    <td><p><keyseq><key>Ctrl</key><key>O</key></keyseq></p></td>
+    </tr>
+    <tr>
+    <td><p>Decimal</p></td>
+    <td><p><keyseq><key>Ctrl</key><key>D</key></keyseq></p></td>
+    </tr>
+    <tr>
+    <td><p>Hexadecimal</p></td>
+    <td><p><keyseq><key>Ctrl</key><key>H</key></keyseq></p></td>
+    </tr>
+    </table>
+    <p>
+    To cycle between history entries you may use:
+    </p>
+    <table>
+    <tr>
+    <td><p>Previous Entry</p></td>
+    <td><p><keyseq><key>Alt</key><key>Up</key></keyseq></p></td>
+    </tr>
+    <tr>
+    <td><p>Next Entry</p></td>
+    <td><p><keyseq><key>Alt</key><key>Down</key></keyseq></p></td>
+    </tr>
+    </table>
 </page>

--- a/src/math-history-entry.c
+++ b/src/math-history-entry.c
@@ -88,6 +88,12 @@ math_history_entry_insert_entry(MathHistoryEntry *history_entry, const gchar *eq
     #undef get_widget
 }
 
+gchar *
+math_history_entry_get_equation(MathHistoryEntry *history_entry)
+{
+    return gtk_widget_get_tooltip_text(history_entry->priv->equation_label);
+}
+
 static void
 math_history_entry_class_init(MathHistoryEntryClass *klass)
 {

--- a/src/math-history-entry.h
+++ b/src/math-history-entry.h
@@ -44,6 +44,9 @@ math_history_entry_new(MathEquation *equation);
 void
 math_history_entry_insert_entry(MathHistoryEntry *history_entry, const gchar *equation, const gchar *answer_four_digits, const gchar *answer_nine_digits);
 
+gchar *
+math_history_entry_get_equation(MathHistoryEntry *history_entry);
+
 G_END_DECLS
 
 #endif /* MATH_HISTORY_ENTRY_VIEW_H */

--- a/src/math-history.h
+++ b/src/math-history.h
@@ -45,6 +45,15 @@ math_history_new(MathEquation *equation);
 void
 math_history_insert_entry(MathHistory *history, char *equation, MPNumber *answer, int number_base);
 
+gpointer
+math_history_get_entry_at(MathHistory *history, int index);
+
+void
+math_history_set_current(MathHistory *history, int value);
+
+int
+math_history_get_current(MathHistory *history);
+
 void
 math_history_clear(MathHistory *history);
 

--- a/src/math-window.c
+++ b/src/math-window.c
@@ -202,7 +202,29 @@ key_press_cb(MathWindow *window, GdkEventKey *event)
     gboolean result;
     g_signal_emit_by_name(window->priv->display, "key-press-event", event, &result);
 
-    if (math_buttons_get_mode (window->priv->buttons) == PROGRAMMING && (event->state & GDK_CONTROL_MASK) == GDK_CONTROL_MASK) {
+    /* Keyboard navigation for history */
+    if ((event->state & GDK_MOD1_MASK) == GDK_MOD1_MASK && (event->keyval == GDK_KEY_Up || event->keyval == GDK_KEY_Down))
+    {
+        switch (event->keyval)
+        {
+            case GDK_KEY_Up:
+                math_history_set_current(window->priv->history, -1);
+                break;
+            case GDK_KEY_Down:
+                math_history_set_current(window->priv->history, 1);
+                break;
+        }
+
+        MathHistoryEntry *entry = math_history_get_entry_at(window->priv->history, math_history_get_current(window->priv->history));
+        if (entry)
+        {
+            gchar *equation_string = math_history_entry_get_equation(entry);
+            math_equation_set(window->priv->equation, equation_string);
+            g_free(equation_string);
+        }
+        return TRUE;
+    }
+    else if (math_buttons_get_mode (window->priv->buttons) == PROGRAMMING && (event->state & GDK_CONTROL_MASK) == GDK_CONTROL_MASK) {
         switch(event->keyval)
         {
         /* Binary */
@@ -540,7 +562,7 @@ static void create_menu(MathWindow* window)
 
     menu = add_menu(window->priv->menu_bar, VIEW_MENU_LABEL);
     window->priv->view_history_menu_item = add_menu_item(menu, gtk_check_menu_item_new_with_mnemonic(VIEW_HISTORY_LABEL), G_CALLBACK(history_check_toggled_cb), window);
-    gtk_widget_add_accelerator(window->priv->view_history_menu_item, "activate", accel_group, GDK_KEY_H, GDK_CONTROL_MASK, GTK_ACCEL_VISIBLE);
+    gtk_widget_add_accelerator(window->priv->view_history_menu_item, "activate", accel_group, GDK_KEY_H, GDK_CONTROL_MASK | GDK_SHIFT_MASK, GTK_ACCEL_VISIBLE);
 
     menu = add_menu(window->priv->menu_bar, HELP_MENU_LABEL);
     menu_item = add_menu_item(menu, gtk_image_menu_item_new_from_icon("help-browser", HELP_CONTENTS_LABEL, accel_group), G_CALLBACK(help_cb), window);


### PR DESCRIPTION
using alt+Up/Down, changed show history shortcut from` ctr+h` to `shift+ctrl+h` such that it does not interfere with hexadecimal shortcut `ctrl+h` when in programming mode and update keyboard shortcuts help page.
Similar to: https://gitlab.gnome.org/GNOME/gnome-calculator/-/commit/8417af309b59f8e5e575197fafad247c955337b5