### PR TITLE
Refresh bits panel after calculation

### DIFF
--- a/src/math-equation.c
+++ b/src/math-equation.c
@@ -997,6 +997,9 @@ math_equation_set_number(MathEquation *equation, const MPNumber *x)
     equation->priv->ans_start = gtk_text_buffer_create_mark(GTK_TEXT_BUFFER(equation), NULL, &start, FALSE);
     equation->priv->ans_end = gtk_text_buffer_create_mark(GTK_TEXT_BUFFER(equation), NULL, &end, TRUE);
     gtk_text_buffer_apply_tag(GTK_TEXT_BUFFER(equation), equation->priv->ans_tag, &start, &end);
+
+    g_object_notify(G_OBJECT(equation), "display");
+
     g_free(text);
     free_state(state);
 }


### PR DESCRIPTION
fixes issue in programming mode:

> to reproduce:
> 256 * 256 * 256 * 256 * 256
> expected:
> 0000 0000 0000 0000 0000 0001 0000 0000
> 0000 0000 0000 0000 0000 0000 0000 0000
> actual:
> greys out

https://gitlab.gnome.org/GNOME/gnome-calculator/-/issues/38