### PR TITLE
Clear answer if editing right before it

### DIFF
--- a/src/math-equation.c
+++ b/src/math-equation.c
@@ -1856,8 +1856,8 @@ pre_insert_text_cb(MathEquation  *equation,
         offset = gtk_text_iter_get_offset(location);
         get_ans_offsets(equation, &ans_start, &ans_end);
 
-        /* Inserted inside ans */
-        if (offset > ans_start && offset < ans_end)
+        /* Inserted inside or right before ans */
+        if (offset >= ans_start && offset < ans_end)
             clear_ans(equation, TRUE);
     }
 }


### PR DESCRIPTION
fixes the issue:

> Press 7 and Enter. Screen should show 7 = 7, input field should show 7.
> Press left arrow and type 12, then the right arrow and type +7. Input field should show 127+7.
> Press Enter. Screen will show 127+7 = 91, input field will show 91

https://gitlab.gnome.org/GNOME/gnome-calculator/-/issues/59