### PR TITLE
Correct Astronomical unit (to 149597870700 m)

### DIFF
--- a/src/unit-manager.c
+++ b/src/unit-manager.c
@@ -56,7 +56,7 @@ unit_manager_get_default(void)
         {NULL,       "gradian",             N_("Gradians"),          NC_("unit-format", "%s gradians"), "π*x/200",            "200x/π",         NC_("unit-symbols", "gradian,gradians,grad")},
         {"length",   "parsec",              N_("Parsecs"),           NC_("unit-format", "%s pc"),       "30857000000000000x", "x/30857000000000000", NC_("unit-symbols", "parsec,parsecs,pc")},
         {NULL,       "lightyear",           N_("Light Years"),       NC_("unit-format", "%s ly"),       "9460730472580800x",  "x/9460730472580800",  NC_("unit-symbols", "lightyear,lightyears,ly")},
-        {NULL,       "astronomical-unit",   N_("Astronomical Units"), NC_("unit-format", "%s au"),      "149597870691x",      "x/149597870691", NC_("unit-symbols", "au")},
+        {NULL,       "astronomical-unit",   N_("Astronomical Units"), NC_("unit-format", "%s au"),      "149597870700x",      "x/149597870700", NC_("unit-symbols", "au")},
         {NULL,       "nautical-mile",       N_("Nautical Miles"),    NC_("unit-format", "%s nmi"),      "1852x",              "x/1852",         NC_("unit-symbols", "nmi")},
         {NULL,       "mile",                N_("Miles"),             NC_("unit-format", "%s mi"),       "1609.344x",          "x/1609.344",     NC_("unit-symbols", "mile,miles,mi")},
         {NULL,       "kilometer",           N_("Kilometers"),        NC_("unit-format", "%s km"),       "1000x",              "x/1000",         NC_("unit-symbols", "kilometer,kilometers,km,kms")},


### PR DESCRIPTION
The IAU changed the definition back in 2012 so that 1 au == 149 597 870 700 m exactly, the BIPM then followed in recognizing this value.

Ref:
https://www.nature.com/news/the-astronomical-unit-gets-fixed-1.11416 (doi:10.1038/nature.2012.11416)
https://www.bipm.org/utils/common/pdf/si-brochure/SI-Brochure-9.pdf (latest brochure, specifically Tableau 8)