### PR TITLE
Remove unused macros

### DIFF
--- a/src/math-buttons.c
+++ b/src/math-buttons.c
@@ -69,9 +69,6 @@ G_DEFINE_TYPE_WITH_PRIVATE (MathButtons, math_buttons, GTK_TYPE_BOX);
 #define GET_WIDGET(ui, name) \
           GTK_WIDGET(gtk_builder_get_object((ui), (name)))
 
-#define WM_WIDTH_FACTOR  10
-#define WM_HEIGHT_FACTOR 30
-
 typedef enum
 {
     NUMBER,

--- a/src/math-equation.c
+++ b/src/math-equation.c
@@ -49,8 +49,6 @@ enum {
 
 static GType number_mode_type, number_format_type, angle_unit_type;
 
-#define MAX_DIGITS 512
-
 /* Expression mode state */
 typedef struct {
     MPNumber ans;              /* Previously calculated answer */


### PR DESCRIPTION
```
math-buttons.c:73: warning: macro "WM_HEIGHT_FACTOR" is not used [-Wunused-macros]
   73 | #define WM_HEIGHT_FACTOR 30
--
math-buttons.c:72: warning: macro "WM_WIDTH_FACTOR" is not used [-Wunused-macros]
   72 | #define WM_WIDTH_FACTOR  10
--
math-equation.c:52: warning: macro "MAX_DIGITS" is not used [-Wunused-macros]
   52 | #define MAX_DIGITS 512
```