### PR TITLE
Remove warning about unused parameters in `ìnt main` function

### DIFF
--- a/src/mate-calc-cmd.c
+++ b/src/mate-calc-cmd.c
@@ -67,7 +67,7 @@ str_adjust(char *str)
 }
 
 int
-main(int argc, char **argv)
+main(void)
 {
     char *equation, *line;
 

--- a/src/test-mp-equation.c
+++ b/src/test-mp-equation.c
@@ -683,7 +683,7 @@ test_equations(void)
 
 
 int
-main (int argc, char **argv)
+main (void)
 {
     setlocale(LC_ALL, "C");
 

--- a/src/test-mp.c
+++ b/src/test-mp.c
@@ -221,7 +221,7 @@ test_mp(void)
 
 
 int
-main (int argc, char **argv)
+main (void)
 {
     setlocale(LC_ALL, "C");
 


### PR DESCRIPTION
test
```
$ make -C src check-TESTS
```
warnings
```
mate-calc-cmd.c:70:10: warning: unused parameter 'argc' [-Wunused-parameter]
mate-calc-cmd.c:70:23: warning: unused parameter 'argv' [-Wunused-parameter]
test-mp-equation.c:686:11: warning: unused parameter 'argc' [-Wunused-parameter]
test-mp-equation.c:686:24: warning: unused parameter 'argv' [-Wunused-parameter]
test-mp.c:224:11: warning: unused parameter 'argc' [-Wunused-parameter]
test-mp.c:224:24: warning: unused parameter 'argv' [-Wunused-parameter]
```