### PR TITLE
build: add configure summary

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -89,3 +89,16 @@ po/Makefile.in
 data/Makefile
 help/Makefile
 ])
+
+echo "
+Configure summary:
+
+    ${PACKAGE_STRING}
+    `echo $PACKAGE_STRING | sed "s/./=/g"`
+
+    prefix:                       ${prefix}
+    source code location:         ${srcdir}
+    compiler:                     ${CC}
+    compiler flags:               ${CFLAGS}
+    warning flags:                ${WARN_CFLAGS}
+"


### PR DESCRIPTION
```
$ ./autogen.sh --prefix=/usr
<cut>

Configure summary:

    mate-calc 1.25.0
    ================

    prefix:                       /usr
    source code location:         .
    compiler:                     gcc
    compiler flags:               -g -O2
    warning flags:                -Wall -Wmissing-prototypes

Now type `make' to compile mate-calc
```