### PR TITLE
mp.c: mp_reciprocal: fix when calling it with same arguments.

### DIFF
--- a/src/mp.c
+++ b/src/mp.c
@@ -403,8 +403,11 @@ mp_invert_sign(const MPNumber *x, MPNumber *z)
 void
 mp_reciprocal(const MPNumber *x, MPNumber *z)
 {
-    mpc_set_si(z->num, 1, MPC_RNDNN);
-    mpc_fr_div(z->num, mpc_realref(z->num), x->num, MPC_RNDNN);
+    mpc_t temp;
+    mpc_init2(temp, PRECISION);
+    mpc_set_ui(temp, 1, MPC_RNDNN);
+    mpc_fr_div(z->num, mpc_realref(temp), x->num, MPC_RNDNN);
+    mpc_clear(temp);
 }
 
 void


### PR DESCRIPTION
The z value was set to 1, which is the same as the x value if both addresses x and z are equal. Thus, the final value of z was 1/1=1. Solved by making a temp variable.

No need to backport, because culprit b0117b1d5ae73916c6f0d289be1f693bb5f46824 is not in the 1.24 branch.