### PR TITLE
fix memory leaks reported by valgrind

### DIFF
--- a/src/math-buttons.c
+++ b/src/math-buttons.c
@@ -354,7 +354,7 @@ load_finc_dialogs(MathButtons *buttons)
 static void
 update_bit_panel(MathButtons *buttons)
 {
-    MPNumber x = mp_new();
+    MPNumber x;
     gboolean enabled;
     guint64 bits;
     int i;
@@ -364,6 +364,7 @@ update_bit_panel(MathButtons *buttons)
     if (!buttons->priv->bit_panel)
         return;
 
+    x = mp_new();
     enabled = math_equation_get_number(buttons->priv->equation, &x);
 
     if (enabled) {
@@ -384,7 +385,10 @@ update_bit_panel(MathButtons *buttons)
     gtk_widget_set_sensitive(buttons->priv->base_label, enabled);
 
     if (!enabled)
+    {
+        mp_clear(&x);
         return;
+    }
 
     for (i = 0; i < MAXBITS; i++) {
         const gchar *bin_label;

--- a/src/mp-serializer.c
+++ b/src/mp-serializer.c
@@ -637,14 +637,20 @@ mp_serializer_class_init(MpSerializerClass *klass)
 static void
 mp_serializer_init(MpSerializer *serializer)
 {
-    gchar *radix, *tsep;
+    gchar *radix, *utf8_radix, *tsep;
     serializer->priv = mp_serializer_get_instance_private (serializer);
 
     radix = nl_langinfo(RADIXCHAR);
-    serializer->priv->radix = radix ? g_utf8_get_char(g_locale_to_utf8(radix, -1, NULL, NULL, NULL)) : '.';
+    utf8_radix = g_locale_to_utf8(radix, -1, NULL, NULL, NULL);
+    serializer->priv->radix = radix ? g_utf8_get_char(utf8_radix) : '.';
+    g_free(utf8_radix);
     tsep = nl_langinfo(THOUSEP);
     if (tsep && tsep[0] != '\0')
-        serializer->priv->tsep = g_utf8_get_char(g_locale_to_utf8(tsep, -1, NULL, NULL, NULL));
+    {
+        gchar *utf8_tsep = g_locale_to_utf8(tsep, -1, NULL, NULL, NULL);
+        serializer->priv->tsep = g_utf8_get_char(utf8_tsep);
+        g_free(utf8_tsep);
+    }
     else
         serializer->priv->tsep = ' ';
     serializer->priv->tsep_count = 3;


### PR DESCRIPTION
I am not quite sure if you have to free the string returned by `g_locale_to_utf8`