### PR TITLE
build: abort configuration when development library for MPC is missing

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,7 +45,7 @@ GLIB_MKENUMS=`$PKG_CONFIG --variable=glib_mkenums glib-2.0`
 AC_SUBST(GLIB_MKENUMS)
 
 AC_CHECK_LIB(m, log)
-AC_CHECK_LIB(mpc, log)
+AC_CHECK_LIB(mpc, log, [], [AC_MSG_ERROR(could not find required development libraries for MPC)], [])
 
 dnl ###########################################################################
 dnl Internationalization


### PR DESCRIPTION
closes #192

Test:
```
$ ./autogen.sh --prefix=/usr
$ grep HAVE_LIBMPC config.h
#define HAVE_LIBMPC 1
$ grep "^LIBS =" Makefile
LIBS = -lmpc -lm 
$ make V=1 &> make.log
$ grep "\-lmpc" make.log
gcc  -g -O2   -o mate-calc mate-calc.o currency.o currency-manager.o math-buttons.o math-converter.o math-history.o math-history-entry.o math-display.o math-equation.o math-preferences.o math-variables.o math-variable-popup.o math-window.o mp.o mp-binary.o mp-convert.o mp-enums.o mp-equation.o mp-serializer.o mp-trigonometric.o financial.o unit.o unit-category.o unit-manager.o prelexer.o lexer.o parserfunc.o parser.o mate-calc-resources.o -lgtk-3 -lgdk-3 -lpangocairo-1.0 -lpango-1.0 -lharfbuzz -latk-1.0 -lcairo-gobject -lcairo -lgdk_pixbuf-2.0 -lgio-2.0 -lgobject-2.0 -lmpfr -lgmp -lxml2 -Wl,--export-dynamic -lgmodule-2.0 -pthread -lglib-2.0 -lglib-2.0  -lmpc -lm 
gcc  -g -O2   -o mate-calc-cmd mate-calc-cmd.o currency.o currency-manager.o mp.o mp-binary.o mp-convert.o mp-enums.o mp-equation.o mp-serializer.o mp-trigonometric.o unit.o unit-category.o unit-manager.o prelexer.o lexer.o parserfunc.o parser.o -lgio-2.0 -lgobject-2.0 -lglib-2.0 -lmpfr -lgmp -lxml2  -lmpc -lm 
gcc  -g -O2   -o test-mp test-mp.o mp.o mp-binary.o mp-convert.o mp-enums.o mp-serializer.o mp-trigonometric.o -lgio-2.0 -lgobject-2.0 -lglib-2.0 -lmpfr -lgmp -lxml2  -lmpc -lm 
gcc  -g -O2   -o test-mp-equation test-mp-equation.o currency.o currency-manager.o mp.o mp-convert.o mp-binary.o mp-enums.o mp-equation.o mp-serializer.o mp-trigonometric.o unit.o unit-category.o unit-manager.o prelexer.o lexer.o parserfunc.o parser.o -lgio-2.0 -lgobject-2.0 -lglib-2.0 -lmpfr -lgmp -lxml2  -lmpc -lm 
```
Test 2 (Fedora):
```
$ rm -f config.h
$ sudo dnf remove -y libmpc-devel
<cut>
checking for log in -lmpc... no
configure: error: could not find required development libraries for MPC
```