### PR TITLE
tx: migrate config file

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,17 +1,17 @@
 [main]
 host = https://www.transifex.com
- 
-[MATE.master--mate-calc]
-file_filter = po/<lang>.po
-source_file = mate-calc.pot
-source_lang = en
-type = PO
+
+[o:mate:p:MATE:r:master--mate-calc]
+file_filter  = po/<lang>.po
+source_file  = mate-calc.pot
+source_lang  = en
+type         = PO
 minimum_perc = 2
 
-[MATE.master--mate-calc-user-guide]
-file_filter = help/<lang>/<lang>.po
-source_file = help/mate-calc.pot
-source_lang = en
-type = PO
+[o:mate:p:MATE:r:master--mate-calc-user-guide]
+file_filter  = help/<lang>/<lang>.po
+source_file  = help/mate-calc.pot
+source_lang  = en
+type         = PO
 minimum_perc = 2
 

--- a/.tx/config_20221024111755.bak
+++ b/.tx/config_20221024111755.bak
@@ -1,0 +1,17 @@
+[main]
+host = https://www.transifex.com
+ 
+[MATE.master--mate-calc]
+file_filter = po/<lang>.po
+source_file = mate-calc.pot
+source_lang = en
+type = PO
+minimum_perc = 2
+
+[MATE.master--mate-calc-user-guide]
+file_filter = help/<lang>/<lang>.po
+source_file = help/mate-calc.pot
+source_lang = en
+type = PO
+minimum_perc = 2
+


### PR DESCRIPTION
This is the result of running `tx migrate` in this repository. This is needed because the old client will be deprecated at the end of November, see https://docs.transifex.com/client/introduction. I plan to do this for all repositories.