### PR TITLE
Fix implicit function declarations with libxml2 2.12

### DIFF
--- a/src/currency-manager.c
+++ b/src/currency-manager.c
@@ -14,6 +14,7 @@
 #include <glib/gstdio.h>
 #include <gio/gio.h>
 #include <libxml/tree.h>
+#include <libxml/parser.h>
 #include <libxml/xpath.h>
 #include <libxml/xpathInternals.h>
 #include <glib/gi18n.h>


### PR DESCRIPTION
```
currency-manager.c: In function ‘load_ecb_rates’:
currency-manager.c:483:5: warning: implicit declaration of function ‘xmlInitParser’ [-Wimplicit-function-declaration]
  483 |     xmlInitParser();
      |     ^~~~~~~~~~~~~
currency-manager.c:485:16: warning: implicit declaration of function ‘xmlReadFile’ [-Wimplicit-function-declaration]
  485 |     document = xmlReadFile(filename, NULL, 0);
      |                ^~~~~~~~~~~
currency-manager.c:485:14: warning: assignment to ‘xmlDocPtr’ {aka ‘struct _xmlDoc *’} from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
  485 |     document = xmlReadFile(filename, NULL, 0);
      |              ^
currency-manager.c:523:5: warning: implicit declaration of function ‘xmlCleanupParser’ [-Wimplicit-function-declaration]
  523 |     xmlCleanupParser();
      |     ^~~~~~~~~~~~~~~~
```

Tested with 2.12.0 and 2.9.14.