### PR TITLE
Set imaginary component to +0*i when inverting a real number

### DIFF
--- a/src/mp.c
+++ b/src/mp.c
@@ -398,6 +398,10 @@ void
 mp_invert_sign(const MPNumber *x, MPNumber *z)
 {
     mpc_neg(z->num, x->num, MPC_RNDNN);
+    if (!mp_is_complex(x))
+    {
+        mpfr_set_zero(mpc_imagref(z->num), MPFR_RNDN);
+    }
 }
 
 void


### PR DESCRIPTION
see https://gitlab.gnome.org/GNOME/gnome-calculator/-/merge_requests/457

fixes #239 