### PR TITLE
Don't use automatic exponential format when not in base 10

### DIFF
--- a/src/mp-serializer.c
+++ b/src/mp-serializer.c
@@ -395,7 +395,7 @@ mp_serializer_to_string(MpSerializer *serializer, const MPNumber *x)
     default:
     case MP_DISPLAY_FORMAT_AUTOMATIC:
         s0 = mp_to_string(serializer, x, &n_digits);
-        if (n_digits <= serializer->priv->leading_digits)
+        if (serializer->priv->base != 10 || n_digits <= serializer->priv->leading_digits)
             return s0;
         else {
             g_free (s0);


### PR DESCRIPTION
Backported from https://gitlab.gnome.org/GNOME/gnome-calculator/-/commit/6fb01c44

Fixes #243