### PR TITLE
add `calc-button-panel` css class for theming

### DIFF
--- a/src/buttons-advanced.ui
+++ b/src/buttons-advanced.ui
@@ -13,6 +13,7 @@
         <property name="can_focus">False</property>
         <property name="row_homogeneous">True</property>
         <property name="column_homogeneous">True</property>
+        <style><class name="calc-button-panel"/></style>
         <child>
           <object class="GtkButton" id="calc_factor_button">
             <property name="label">a×b</property>

--- a/src/buttons-basic.ui
+++ b/src/buttons-basic.ui
@@ -13,6 +13,7 @@
         <property name="can_focus">False</property>
         <property name="row_homogeneous">True</property>
         <property name="column_homogeneous">True</property>
+        <style><class name="calc-button-panel"/></style>
         <child>
           <object class="GtkButton" id="calc_4_button">
             <property name="label">4</property>

--- a/src/buttons-financial.ui
+++ b/src/buttons-financial.ui
@@ -1848,6 +1848,7 @@
         <property name="can_focus">False</property>
         <property name="row_homogeneous">True</property>
         <property name="column_homogeneous">True</property>
+        <style><class name="calc-button-panel"/></style>
         <child>
           <object class="GtkButton" id="calc_memory_button">
             <property name="visible">True</property>

--- a/src/buttons-programming.ui
+++ b/src/buttons-programming.ui
@@ -115,6 +115,7 @@
         <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
         <property name="spacing">6</property>
+        <style><class name="calc-button-panel"/></style>
         <child>
           <object class="GtkBox" id="hbox1">
             <property name="visible">True</property>


### PR DESCRIPTION
#54 was really bugging me since I use materia-based theme. I checked inspector and there was no appropriate class to apply styles specifically to the button_panel grid so I tried adding this class and it seems fine for all modes

<img width="988" height="539" alt="image" src="https://github.com/user-attachments/assets/1e68eac7-a230-442c-8b13-4b41059c60a4" />

<img width="995" height="364" alt="Screenshot_2026-08-02_07-00-51" src="https://github.com/user-attachments/assets/c1279658-26b2-4d12-8dca-9b7af81ac27c" />

<img width="994" height="495" alt="Screenshot_2026-08-02_07-01-42" src="https://github.com/user-attachments/assets/d7816bb6-66bd-4341-b37b-9579c793dcd0" />

Please accept this PR :pray: 